### PR TITLE
Modernize site visual style with typography, theming, and post cards

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,11 +2,23 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {% favicon %}
 {% seo %}
-<link href='https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
-<link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+<script>
+  // No-flash dark mode: applies the saved theme before paint.
+  (function () {
+    try {
+      var stored = localStorage.getItem('theme');
+      var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var theme = stored || (prefersDark ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+    } catch (e) {}
+  })();
+</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Source+Serif+Pro:ital,wght@0,400;0,600;1,400;1,600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <script defer src="https://use.fontawesome.com/releases/v5.15.4/js/all.js" integrity="sha384-rOA1PnstxnOBLzCLMcre8ybwbTmemjzdNlILg8O7z1lUkLXozs4DHonlDtnE7fpc" crossorigin="anonymous"></script>
 <script async src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.1.3/mermaid.min.js"integrity="sha512-E/owfVh8/U1xwhvIT4HSI064DRc1Eo/xf7AYax84rt9gVqA8tc/JNH/lvTl1tuw9PUHQIMGUtObkjYkgRjFqAA==" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="{{"/assets/main.css" | relative_url }}">
-<link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}"> 
-  
+<link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+
 </head>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -20,6 +20,12 @@
         <li class="nav-item">
           <a class="nav-link" href="{{"/contact" | relative_url }}">Contact</a>
         </li>
+        <li class="nav-item d-flex align-items-center">
+          <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+            <em class="fas fa-moon icon-moon" aria-hidden="true"></em>
+            <em class="fas fa-sun icon-sun" aria-hidden="true"></em>
+          </button>
+        </li>
       </ul>
     </div>
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -30,31 +30,32 @@ layout: default
         {{ content }}
 
         <!-- Home Post List -->
-        {% for post in site.posts limit : 5 %}
-
-        <article class="post-preview">
-          <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
-            <h2 class="post-title">{{ post.title }}</h2>
-            {% if post.subtitle %}
-            <h3 class="post-subtitle">{{ post.subtitle }}</h3>
-            {% else %}
-            <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
-            {% endif %}
-          </a>
-          <p class="post-meta">Posted by
-            {% if post.author %}
-            {{ post.author }}
-            {% else %}
-            {{ site.author }}
-            {% endif %}
-            on
-            {{ post.date | date: '%B %d, %Y' }} &middot; {% include read_time.html content=post.content %}            
-          </p>
-        </article>
-
-        <hr>
-
-        {% endfor %}
+        <div class="post-list">
+          {% for post in site.posts limit : 5 %}
+          {% assign card_image = post.background | default: '/img/posts/1.jpg' %}
+          <article class="post-card">
+            <a class="post-card__media" href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
+              <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}" alt="" loading="lazy">
+            </a>
+            <div class="post-card__body">
+              <h2 class="post-card__title">
+                <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">{{ post.title }}</a>
+              </h2>
+              <p class="post-card__subtitle">
+                {% if post.subtitle %}
+                  {{ post.subtitle }}
+                {% else %}
+                  {{ post.excerpt | strip_html | truncatewords: 18 }}
+                {% endif %}
+              </p>
+              <div class="post-card__meta">
+                <span class="meta-chip"><em class="far fa-calendar-alt"></em>{{ post.date | date: '%b %d, %Y' }}</span>
+                <span class="meta-chip"><em class="far fa-clock"></em>{% include read_time.html content=post.content %}</span>
+              </div>
+            </div>
+          </article>
+          {% endfor %}
+        </div>
 
         <!-- Pager -->
         <div class="clearfix">

--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -2,7 +2,602 @@
 @import "../assets/vendor/startbootstrap-clean-blog/scss/styles.scss";
 @import "codehighlights.css";
 
-// Modern Footer
+// =============================================================================
+// Design tokens (CSS custom properties) + dark mode
+// =============================================================================
+:root {
+  // Brand
+  --color-accent: #0085A1;
+  --color-accent-hover: #00a3c4;
+  --color-accent-contrast: #ffffff;
+
+  // Surfaces
+  --color-bg: #ffffff;
+  --color-bg-alt: #f7f8fa;
+  --color-surface: #ffffff;
+  --color-surface-elevated: #ffffff;
+  --color-border: #e6e8ec;
+  --color-border-strong: #d2d6dc;
+
+  // Text
+  --color-text: #1a1d23;
+  --color-text-muted: #5b6270;
+  --color-text-subtle: #8a91a0;
+  --color-heading: #0f1115;
+
+  // Code
+  --color-code-bg: #1e1f29;
+  --color-code-text: #e6e8ef;
+  --color-code-inline-bg: #f1f3f6;
+  --color-code-inline-text: #c7254e;
+  --color-code-border: #2a2c38;
+
+  // Shadows
+  --shadow-sm: 0 1px 2px rgba(15, 17, 21, 0.05);
+  --shadow-md: 0 6px 18px rgba(15, 17, 21, 0.08);
+  --shadow-lg: 0 20px 40px rgba(15, 17, 21, 0.12);
+
+  // Type
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               "Helvetica Neue", Arial, sans-serif;
+  --font-serif: "Source Serif Pro", Georgia, "Times New Roman", serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas,
+               "Liberation Mono", monospace;
+
+  // Radius
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+}
+
+[data-theme="dark"] {
+  --color-bg: #0e1014;
+  --color-bg-alt: #161922;
+  --color-surface: #181b24;
+  --color-surface-elevated: #1f2330;
+  --color-border: #262a36;
+  --color-border-strong: #353a4a;
+
+  --color-text: #e3e6ec;
+  --color-text-muted: #9ba3b4;
+  --color-text-subtle: #6b7287;
+  --color-heading: #f5f7fa;
+
+  --color-accent: #4ec9d6;
+  --color-accent-hover: #7bdbe6;
+
+  --color-code-bg: #0b0d12;
+  --color-code-text: #e6e8ef;
+  --color-code-inline-bg: #1f2330;
+  --color-code-inline-text: #ff7eb6;
+  --color-code-border: #262a36;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.6);
+}
+
+// =============================================================================
+// Base typography
+// =============================================================================
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.7;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+p {
+  line-height: 1.75;
+  margin: 1.25em 0;
+
+  a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1.5px;
+
+    &:hover,
+    &:focus {
+      color: var(--color-accent-hover);
+    }
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-sans);
+  color: var(--color-heading);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  line-height: 1.25;
+}
+
+h1 { font-size: clamp(2rem, 4vw, 2.75rem); }
+h2 { font-size: clamp(1.6rem, 3vw, 2.1rem); margin-top: 2em; }
+h3 { font-size: clamp(1.3rem, 2.4vw, 1.55rem); margin-top: 1.6em; }
+h4 { font-size: 1.2rem; margin-top: 1.4em; }
+
+a {
+  color: var(--color-accent);
+
+  &:focus,
+  &:hover {
+    color: var(--color-accent-hover);
+  }
+}
+
+blockquote {
+  font-style: italic;
+  color: var(--color-text-muted);
+  border-left: 4px solid var(--color-accent);
+  background: var(--color-bg-alt);
+  padding: 1em 1.25em;
+  margin: 1.6em 0;
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: 2.5em 0;
+}
+
+::selection {
+  color: var(--color-accent-contrast);
+  background: var(--color-accent);
+  text-shadow: none;
+}
+
+// Container/page background
+.container {
+  // Make sure containers inherit the themed background
+}
+
+body > .container,
+.page-content {
+  background-color: var(--color-bg);
+}
+
+// =============================================================================
+// Navbar (themed)
+// =============================================================================
+#mainNav {
+  font-family: var(--font-sans);
+
+  .navbar-brand {
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  .navbar-nav > li.nav-item > a {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  @media only screen and (min-width: 992px) {
+    &.is-fixed {
+      background-color: rgba(255, 255, 255, 0.85);
+      backdrop-filter: saturate(180%) blur(12px);
+      -webkit-backdrop-filter: saturate(180%) blur(12px);
+      border-bottom-color: var(--color-border);
+
+      [data-theme="dark"] & {
+        background-color: rgba(14, 16, 20, 0.8);
+        border-bottom-color: var(--color-border);
+      }
+
+      .navbar-brand,
+      .navbar-nav > li.nav-item > a {
+        color: var(--color-text);
+      }
+
+      .navbar-brand:hover,
+      .navbar-brand:focus,
+      .navbar-nav > li.nav-item > a:hover,
+      .navbar-nav > li.nav-item > a:focus {
+        color: var(--color-accent);
+      }
+    }
+  }
+}
+
+// Theme toggle button
+.theme-toggle {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: #fff;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-left: 0.75rem;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.15);
+    transform: translateY(-1px);
+  }
+
+  .icon-sun { display: none; }
+  .icon-moon { display: inline; }
+
+  [data-theme="dark"] & {
+    .icon-sun { display: inline; }
+    .icon-moon { display: none; }
+  }
+
+  // When navbar collapses to its scrolled/fixed light state
+  #mainNav.is-fixed & {
+    color: var(--color-text);
+    border-color: var(--color-border-strong);
+
+    &:hover {
+      background-color: var(--color-bg-alt);
+      color: var(--color-accent);
+    }
+  }
+
+  // Mobile (collapsed navbar background is white)
+  @media only screen and (max-width: 991.98px) {
+    color: var(--color-text);
+    border-color: var(--color-border-strong);
+  }
+}
+
+// =============================================================================
+// Masthead / hero
+// =============================================================================
+header.masthead {
+  margin-bottom: 3rem;
+  position: relative;
+
+  .overlay {
+    background-color: transparent;
+    background-image: linear-gradient(
+      180deg,
+      rgba(10, 12, 18, 0.35) 0%,
+      rgba(10, 12, 18, 0.55) 50%,
+      rgba(10, 12, 18, 0.78) 100%
+    );
+    opacity: 1;
+  }
+
+  .page-heading,
+  .post-heading,
+  .site-heading {
+    padding: clamp(120px, 22vh, 200px) 0 clamp(90px, 16vh, 150px);
+
+    @media only screen and (min-width: 768px) {
+      padding: clamp(160px, 24vh, 220px) 0;
+    }
+  }
+
+  .page-heading,
+  .site-heading {
+    h1 {
+      font-size: clamp(2.4rem, 6vw, 4rem);
+      letter-spacing: -0.02em;
+      color: #fff;
+    }
+
+    .subheading {
+      font-size: clamp(1.05rem, 2vw, 1.4rem);
+      font-weight: 400;
+      font-family: var(--font-sans);
+      opacity: 0.92;
+    }
+  }
+
+  .post-heading {
+    h1 {
+      font-size: clamp(2rem, 5vw, 3.25rem);
+      letter-spacing: -0.02em;
+      color: #fff;
+    }
+
+    .subheading {
+      font-size: clamp(1.1rem, 2.2vw, 1.6rem);
+      font-weight: 500;
+      font-family: var(--font-sans);
+      opacity: 0.95;
+    }
+
+    .meta {
+      font-family: var(--font-sans);
+      font-size: 0.95rem;
+      font-style: normal;
+      opacity: 0.85;
+    }
+  }
+}
+
+// =============================================================================
+// Post preview cards
+// =============================================================================
+.post-list {
+  display: grid;
+  gap: 1.75rem;
+  margin: 0 0 2.5rem;
+  padding: 0;
+  list-style: none;
+}
+
+.post-card {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 1.5rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--color-border-strong);
+  }
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+}
+
+.post-card__media {
+  display: block;
+  position: relative;
+  background: var(--color-bg-alt);
+  min-height: 100%;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    min-height: 160px;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.4s ease;
+  }
+
+  .post-card:hover & img {
+    transform: scale(1.04);
+  }
+
+  @media (max-width: 640px) {
+    img { min-height: 180px; max-height: 220px; }
+  }
+}
+
+.post-card__body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.25rem 1.5rem 1.25rem 0;
+
+  @media (max-width: 640px) {
+    padding: 1.25rem 1.4rem 1.5rem;
+  }
+}
+
+.post-card__title {
+  font-family: var(--font-sans);
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0 0 0.4rem;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+
+  a {
+    color: var(--color-heading);
+    text-decoration: none;
+
+    &:hover { color: var(--color-accent); }
+  }
+}
+
+.post-card__subtitle {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  color: var(--color-text-muted);
+  font-weight: 400;
+  margin: 0 0 0.85rem;
+  line-height: 1.55;
+}
+
+.post-card__meta {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  color: var(--color-text-subtle);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.9rem;
+  align-items: center;
+
+  .meta-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.6rem;
+    background-color: var(--color-bg-alt);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+}
+
+// Hide the legacy <hr> separators when using the new card layout
+.post-list + .clearfix hr,
+.post-card + hr { display: none; }
+
+// =============================================================================
+// Buttons (themed)
+// =============================================================================
+.btn-primary {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border-radius: var(--radius-sm);
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: var(--color-accent-hover) !important;
+    border-color: var(--color-accent-hover) !important;
+  }
+}
+
+// =============================================================================
+// Code blocks (rewritten — replaces parts of codehighlights.css visually)
+// =============================================================================
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
+// Inline code
+:not(pre) > code {
+  background-color: var(--color-code-inline-bg);
+  color: var(--color-code-inline-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.12em 0.4em;
+  font-size: 0.88em;
+}
+
+// Block code (Rouge / kramdown wraps code in figure.highlight or div.highlight)
+.highlight,
+figure.highlight,
+div.highlight {
+  position: relative;
+  margin: 1.6em 0;
+  background-color: var(--color-code-bg);
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+
+  pre {
+    background-color: transparent !important;
+    color: var(--color-code-text);
+    margin: 0;
+    padding: 1.1rem 1.2rem;
+    overflow-x: auto;
+    font-size: 0.88rem;
+    line-height: 1.6;
+    border: none;
+  }
+
+  code {
+    background: transparent;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  // Copy button (injected by JS)
+  .copy-code-btn {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.6rem;
+    padding: 0.3rem 0.6rem;
+    font-family: var(--font-sans);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #cdd2dc;
+    background-color: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease, background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  }
+
+  &:hover .copy-code-btn { opacity: 1; }
+
+  .copy-code-btn:hover {
+    background-color: rgba(255, 255, 255, 0.14);
+    color: #fff;
+  }
+
+  .copy-code-btn.is-copied {
+    background-color: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+    opacity: 1;
+  }
+}
+
+// =============================================================================
+// Post body images / tables (small polish that pairs with the theme)
+// =============================================================================
+.post-content,
+article {
+  img {
+    max-width: 100%;
+    height: auto;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    margin: 1.2em 0;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5em 0;
+    font-family: var(--font-sans);
+    font-size: 0.95rem;
+
+    th, td {
+      border: 1px solid var(--color-border);
+      padding: 0.6rem 0.8rem;
+      text-align: left;
+    }
+
+    th {
+      background-color: var(--color-bg-alt);
+      font-weight: 600;
+    }
+  }
+}
+
+// =============================================================================
+// Reduced motion
+// =============================================================================
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+// =============================================================================
+// Modern Footer (existing)
+// =============================================================================
 .footer-modern {
   font-size: 0.9rem;
 

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -1,3 +1,87 @@
 $(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
+  $('[data-toggle="tooltip"]').tooltip();
+});
+
+(function () {
+  // ---------------------------------------------------------------------------
+  // Theme toggle (light/dark)
+  // ---------------------------------------------------------------------------
+  function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    try { localStorage.setItem('theme', theme); } catch (e) {}
+  }
+
+  function initThemeToggle() {
+    var btn = document.querySelector('.theme-toggle');
+    if (!btn) return;
+
+    btn.addEventListener('click', function () {
+      var current = document.documentElement.getAttribute('data-theme') || 'light';
+      applyTheme(current === 'dark' ? 'light' : 'dark');
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Copy-to-clipboard buttons on code blocks
+  // ---------------------------------------------------------------------------
+  function initCodeCopyButtons() {
+    var blocks = document.querySelectorAll('div.highlight, figure.highlight, .highlight');
+    blocks.forEach(function (block) {
+      if (block.querySelector('.copy-code-btn')) return;
+
+      var pre = block.querySelector('pre');
+      if (!pre) return;
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'copy-code-btn';
+      btn.setAttribute('aria-label', 'Copy code to clipboard');
+      btn.textContent = 'Copy';
+
+      btn.addEventListener('click', function () {
+        var code = pre.innerText;
+        var done = function () {
+          btn.textContent = 'Copied';
+          btn.classList.add('is-copied');
+          setTimeout(function () {
+            btn.textContent = 'Copy';
+            btn.classList.remove('is-copied');
+          }, 1800);
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(code).then(done).catch(function () {
+            fallbackCopy(code, done);
+          });
+        } else {
+          fallbackCopy(code, done);
+        }
+      });
+
+      block.appendChild(btn);
+    });
+  }
+
+  function fallbackCopy(text, done) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'absolute';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy'); } catch (e) {}
+    document.body.removeChild(ta);
+    if (done) done();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () {
+      initThemeToggle();
+      initCodeCopyButtons();
+    });
+  } else {
+    initThemeToggle();
+    initCodeCopyButtons();
+  }
+})();

--- a/posts/index.html
+++ b/posts/index.html
@@ -4,30 +4,32 @@ title: Posts
 background: '/img/bg-post.jpg'
 ---
 
-{% for post in paginator.posts %}
-
-<article class="post-preview">
-  <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
-    <h2 class="post-title">{{ post.title }}</h2>
-    {% if post.subtitle %}
-    <h3 class="post-subtitle">{{ post.subtitle }}</h3>
-    {% else %}
-    <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
-    {% endif %}
-  </a>
-  <p class="post-meta">Posted by
-    {% if post.author %}
-    {{ post.author }}
-    {% else %}
-    {{ site.author }}
-    {% endif %}
-    on {{ post.date | date: '%B %d, %Y' }} &middot; {% include read_time.html content=post.content %}
-  </p>
-</article>
-
-<hr>
-
-{% endfor %}
+<div class="post-list">
+  {% for post in paginator.posts %}
+  {% assign card_image = post.background | default: '/img/posts/1.jpg' %}
+  <article class="post-card">
+    <a class="post-card__media" href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
+      <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}" alt="" loading="lazy">
+    </a>
+    <div class="post-card__body">
+      <h2 class="post-card__title">
+        <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">{{ post.title }}</a>
+      </h2>
+      <p class="post-card__subtitle">
+        {% if post.subtitle %}
+          {{ post.subtitle }}
+        {% else %}
+          {{ post.excerpt | strip_html | truncatewords: 18 }}
+        {% endif %}
+      </p>
+      <div class="post-card__meta">
+        <span class="meta-chip"><em class="far fa-calendar-alt"></em>{{ post.date | date: '%b %d, %Y' }}</span>
+        <span class="meta-chip"><em class="far fa-clock"></em>{% include read_time.html content=post.content %}</span>
+      </div>
+    </div>
+  </article>
+  {% endfor %}
+</div>
 
 <!-- Pager -->
 {% if paginator.total_pages > 1 %}


### PR DESCRIPTION
- Typography: switch to Inter (sans) + Source Serif Pro (body) +
  JetBrains Mono (code), drop body to 18px with 1.7 line-height,
  and use clamp() for fluid headings.
- Theming: introduce CSS custom properties for colors, surfaces,
  borders, shadows, and radii; add a full dark mode with a navbar
  toggle and a no-flash inline script in head.html.
- Hero: replace flat 0.5 overlay with a vertical gradient and use
  clamp() for vertical padding so mobile heros are less massive.
- Post previews: replace text-only list with image-first cards
  on the homepage and /posts index, sourcing thumbnails from each
  post's `background` front matter.
- Code blocks: dark rounded panels with copy-to-clipboard buttons
  injected by scripts.js, plus styled inline `code` chips.