### PR TITLE
Bootstrap autonomous blog agent ledger

### DIFF
--- a/agent/topics.md
+++ b/agent/topics.md
@@ -1,0 +1,119 @@
+# Konu Defteri
+
+> Otonom yazı ajanının kalıcı belleği. Her çalıştırmada okunur ve güncellenir.
+
+## Yazıldı (yayında)
+
+- [x] Tümleşik Gereksinim Yönetimi — 2022-04-28 — alan: sistem/gereksinim
+- [x] Yazılım Sistem Mühendisliği — 2022-04-29 — alan: sistem
+- [x] Use Case Tuzakları — 2022-05-01 — alan: gereksinim/analiz
+- [x] Yazılım Proje Yönetimi Pratikleri — 2022-05-03 — alan: proje yönetimi
+- [x] Gereksinimler ve Test: Yedi Eksik Bağlantı — 2022-05-08 — alan: gereksinim/test
+- [x] Fonksiyonel Olmayan Yazılım Gereksinimleri — 2022-07-11 — alan: gereksinim
+- [x] CMake — 2022-07-20 — alan: araçlar
+- [x] Elektrik Kesintisinde Otomatik Açılış — 2022-08-15 — alan: sistem
+- [x] Recursively Delete a Specific Folder — 2022-09-11 — alan: araçlar
+- [x] Merge Files with FFmpeg — 2023-03-12 — alan: araçlar
+- [x] Türkiye'de Debugging Aşamaları — 2023-12-01 — alan: kültür/proje
+- [x] Kayan Nokta Sayılarının Tehlikeleri — 2026-03-25 — alan: gömülü/sayısal
+- [x] Versiyon Kontrol: Git vs SVN vs ClearCase — 2026-03-25 — alan: araçlar
+- [x] MISRA C:2025 ile Neler Değişti — 2026-04-05 — alan: standart/C
+- [x] Yöneylem Araştırması Yöntemleri — 2026-04-14 — alan: matematik/optimizasyon
+- [x] Ölçüm Belirsizliği (GUM Annex F + NCSLI RP-12) — 2026-05-06 — alan: metroloji
+- [x] Kalibrasyon Zincirinin Tepesi (Birincil Standartlar) — 2026-05-07 — alan: metroloji
+- [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14 — alan: gömülü/SoC
+
+## Açık PR'lar (insan inceleme bekleniyor — yeni PR açma!)
+
+| PR # | Başlık | Dal | Açılış | Alan |
+|------|--------|-----|--------|------|
+| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi (C/C++, Rust) | post/bellek-guvenligi-devrimi | 2026-04-12 | gömülü/güvenlik |
+| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış (Undefined Behavior) | blog/undefined-behavior | 2026-04-04 | C/derleyici |
+| [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | blog/misra-c-statik-analiz | 2026-03-28 | standart/C (#69 ile çakışma riski!) |
+| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ (eski yazı genişletme) | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
+
+> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. İnceleyen kişinin dikkatine.
+
+## Seçildi / Devam Eden
+
+- (yok — açık PR backlog nedeniyle yeni yazı seçilmedi)
+
+## Reddedildi (bu çalıştırma)
+
+- _(bu çalıştırmada bir konu seçilmedi; yayın kapısı kapalı — bkz. aşağı)_
+
+## Fikir Havuzu (aday konular — gelecek çalıştırma için)
+
+Aşağıdaki adaylar, mevcut yazılar + açık PR'larla çakışmıyor ve Bölüm 6 kriterlerini
+geçici olarak karşılıyor. Faz 2'de tekrar değerlendirilmesi gerekir.
+
+### Yüksek öncelikli (kalıcı değer + Türkçe boşluk)
+
+- [ ] **ARM Cortex-A reset vektöründen `main()`'e: gerçekten ne oluyor?** —
+      alan: gömülü/SoC — Renode yazısının doğal devamı, somut deney imkânı
+- [ ] **MC/DC kapsama: DO-178C DAL A'da neden modified condition/decision şart?** —
+      alan: sertifikasyon — gerçek karar tablosu örneği, decision/condition farkı
+- [ ] **CRC vs checksum: neden CRC-32 değil de CRC-32C / CRC-16-CCITT seçilir?** —
+      alan: yazılım zanaatı — polinom seçimi, hata tespit gücü, bit-hata analizi
+- [ ] **WCET analizi: statik analiz vs ölçüm tabanlı yaklaşımlar, cache etkileri** —
+      alan: gerçek zamanlı — somut örnek (örn. Cortex-R5 üzerinde basit görev)
+- [ ] **Bandpass sampling (undersampling): RF/IF örnekleme tuzakları ve Nyquist'in
+      sandığınız gibi olmadığı durumlar** — alan: DSP — sayısal türetme + örnek
+- [ ] **IQ örnekleme ve karmaşık sinyaller: gerçek SDR'ye giriş** —
+      alan: RF/SDR — neden negatif frekans, neden 2 kanal
+- [ ] **GIC (Generic Interrupt Controller): SGI/PPI/SPI farkları ve önceliklendirme** —
+      alan: ARM — kesme yönlendirme, multicore'da CPU affinity
+- [ ] **Cache coherency ve MESI: ARM'da CCI/CMN ne yapar, neden yazılım perde
+      (barrier) gerekir?** — alan: ARM — pratik race condition örneği
+- [ ] **Linker script anatomisi: ARM bare-metal için bir `.ld` dosyası satır satır** —
+      alan: gömülü — kendi linker script'i yazma rehberi
+- [ ] **Watchdog tasarım desenleri: tek vs çoklu görev watchdog, deadman switch,
+      windowed watchdog** — alan: güvenilirlik — gerçek tasarım kararları
+- [ ] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
+      alan: C/eşzamanlılık — derleyici çıktı analizi
+- [ ] **VOR'un çalışma prensibi: 30 Hz referans + değişken faz nasıl yön verir?** —
+      alan: navigasyon — faz farkı matematiği + sinyal şeması
+- [ ] **ILS anatomisi: localizer 90/150 Hz DDM ve glide slope** —
+      alan: navigasyon — modülasyon derinliği farkı + örnek hesap
+- [ ] **Kalman filtresi tuzakları: numerik stabilite, gözlemlenebilirlik, tuning** —
+      alan: navigasyon/füzyon — basit IMU örneği + Python kodu
+- [ ] **Sabit nokta (Q-format) aritmetik: Cortex-M0'da FPU yokken DSP nasıl yapılır?** —
+      alan: gömülü/DSP — Q15/Q31 örnekleri, overflow yönetimi
+
+### Orta öncelikli (kovaya alındı)
+
+- [ ] DO-330 araç nitelendirme (Tool Qualification) seviyeleri
+- [ ] ARP4754A — sistem geliştirme süreci
+- [ ] DO-326A / ED-202A havacılık siber güvenliği
+- [ ] FMEA pratikte: gerçek bir alt-sistem üzerinden adım adım
+- [ ] Fault Tree Analysis ile minimal cut set hesabı
+- [ ] FPU denormal performansı: Cortex-A vs x86 davranış farkı
+- [ ] Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain
+- [ ] Endianness: ağ baytı vs host baytı, ARM'ın iki modu, bitfield tuzakları
+- [ ] DMA yarış koşulları: ARM'da cache invalidation/clean stratejileri
+- [ ] Lockstep CPU mimarisi: TI Hercules / NXP MPC57xx örnekleri
+- [ ] MPU vs MMU: hangisi ne zaman, FreeRTOS-MPU örneği
+- [ ] Statik analiz neyi yakalar / kaçırır: somut C kodu üzerinden Coverity/Polyspace
+- [ ] Radyasyona dayanıklı yazılım: SEU, TMR, scrubbing
+- [ ] ADS-B sinyal yapısı: PPM modülasyon, mesaj formatı
+- [ ] FIR vs IIR: faz cevabı, hesaplama maliyeti, stabilite
+
+### Düşük öncelikli / sonraya bırak
+
+- [ ] ECSS uzay yazılım standartları ailesi (geniş, alt-konulara bölünmeli)
+- [ ] DO-254 donanım sertifikasyonu (yazarın uzmanlığı ağırlıklı yazılım tarafında)
+- [ ] İzlenebilirlik matrisi (klasik konu, derinlik çıkarmak zor)
+
+## Notlar (bu çalıştırma — 2026-05-18)
+
+- **Yayın kapısı kapalı:** 4 açık blog PR'ı bekliyor. Bölüm 4 sert kuralı gereği yeni
+  PR açılmadı. Çalıştırma "araştırma + defter güncelleme" moduna alındı.
+- Son yayınlanan 3 yazı: Renode (gömülü/SoC), Kalibrasyon (metroloji),
+  Ölçüm belirsizliği (metroloji). Alan rotasyonu için bir sonraki yazı **metroloji ve
+  gömülü/SoC dışı** bir alandan seçilmeli — RF/DSP, navigasyon, sertifikasyon veya
+  ARM mimari detayları iyi adaylar.
+- PR #50 (FTZ/DAZ) zaten yayında olan "Kayan Nokta Sayılarının Tehlikeleri" yazısını
+  *genişletiyor* — yeni yazı değil. Bu, gerçek bir blog PR'ı sayılmaz ama yine de
+  açık duran bir değişiklik. Yorum: insan inceleyene kadar bekle.
+- PR #51 ile yayındaki MISRA C:2025 yazısı muhtemelen çakışıyor; #51 ya
+  kapatılmalı ya da farklı bir açıyla yeniden yazılmalı.


### PR DESCRIPTION
## Özet

Zamanlanmış otonom blog-yazarı ajanın kalıcı durum dosyasını ([agent/topics.md](agent/topics.md)) ilk kez oluşturur. Bu çalıştırmada yeni bir blog yazısı üretilmedi — aşağıdaki sebeplerle.

## Neden bu çalıştırmada yazı yok

Görev dosyasındaki Bölüm 4 sert kuralı: *"Var olan açık bir PR varken yenisi açılmaz; önce mevcut PR'ın insan tarafından sonuçlandırılması beklenir."*

Çalıştırma başında **4 açık blog PR'ı** bulundu:

| PR | Başlık | Açılış |
|----|--------|--------|
| #67 | Bellek Güvenliği Devrimi (C/C++, Rust) | 2026-04-12 |
| #54 | C'de Tanımsız Davranış | 2026-04-04 |
| #51 | MISRA C ve Statik Analiz | 2026-03-28 |
| #50 | Float FTZ/DAZ genişletme | 2026-03-26 |

Ajan, bu backlog kapanmadan yeni blog PR'ı açmıyor. Bunun yerine "araştırma + defter" moduna geçti.

## Bu PR'da ne var

- `agent/topics.md` — defterin ilk sürümü:
  - **Yazıldı:** 18 yayınlanmış post, alan etiketleriyle
  - **Açık PR'lar:** yukarıdaki tablo, link ve gerekçelerle
  - **Fikir Havuzu:** 15 yüksek + 14 orta öncelikli aday konu, hepsi mevcut yazılar ve açık PR'larla çakışmaz şekilde elendi (DO-326A, MC/DC kapsama, ARM GIC, cache coherency, VOR/ILS matematiği, Kalman tuzakları, vb.)
  - **Notlar:** alan rotasyonu önerisi, PR #51 ve yayındaki MISRA C:2025 yazısı arasındaki olası çakışma uyarısı

## İnceleyiciye notlar

1. **PR backlog'unu temizleyin** — ajan bunlar kapanmadan tekrar üretmeye başlamayacak.
2. **PR #51** muhtemelen kapatılmalı veya farklı bir açıyla yeniden yazılmalı; zaten yayında olan [_posts/2026-04-05-misra-c-2025-ile-neler-degisti.md](_posts/2026-04-05-misra-c-2025-ile-neler-degisti.md) ile konu olarak örtüşüyor.
3. **Sonraki yazı için alan rotasyonu:** Son 3 yayın metroloji × 2 + gömülü/SoC × 1 olduğu için bir sonraki yazı RF/DSP, navigasyon veya sertifikasyon alanından seçilmeli — defter bu alanlarda hazır adaylar sunuyor.
4. `agent/research/` ve `agent/drafts/` dizinleri (boş — git tarafından izlenmez) ileride faz 3/5 çıktıları için kullanılacak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)