### PR TITLE
Alt alanlara link ekle (closes #82)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,6 +20,11 @@
             <li><a href="{{ "/posts" | relative_url }}">Yazılar</a></li>
             <li><a href="{{ "/contact" | relative_url }}">İletişim</a></li>
           </ul>
+          <h5 class="footer-heading mt-3">Projeler</h5>
+          <ul class="footer-links">
+            <li><a href="https://karaman.dev/games" target="_blank" rel="noopener">Oyunlar</a></li>
+            <li><a href="https://karaman.dev/or-araclari" target="_blank" rel="noopener">OR Araçları</a></li>
+          </ul>
         </div>
 
         <!-- Social column -->

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -20,6 +20,15 @@
         <li class="nav-item">
           <a class="nav-link" href="{{"/contact" | relative_url }}">İletişim</a>
         </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownProjects" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Projeler
+          </a>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownProjects">
+            <a class="dropdown-item" href="https://karaman.dev/games" target="_blank" rel="noopener">Oyunlar</a>
+            <a class="dropdown-item" href="https://karaman.dev/or-araclari" target="_blank" rel="noopener">OR Araçları</a>
+          </div>
+        </li>
         <li class="nav-item d-flex align-items-center">
           <button type="button" class="theme-toggle" aria-label="Tema değiştir" title="Tema değiştir">
             <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/about.md
+++ b/about.md
@@ -17,7 +17,7 @@ My day-to-day moves between requirements, C and C++ code that has to behave unde
 
 I hold an M.Sc. in Computer Software Engineering from Hacettepe University and a B.Sc. in Electrical, Electronics and Communications Engineering from İzmir Institute of Technology. I'm currently pursuing a second M.Sc. in Systems Engineering.
 
-Outside the day job I write at [karaman.dev](https://karaman.dev/) and [aviyonikyazilim.com](https://www.aviyonikyazilim.com/), ship pet projects on [GitHub](https://github.com/Mavrikant), and have contributed 225,000+ edits and bot scripts to Wikipedia since 2014.
+Outside the day job I write at [karaman.dev](https://karaman.dev/) and [aviyonikyazilim.com](https://www.aviyonikyazilim.com/), ship pet projects on [GitHub](https://github.com/Mavrikant), and have contributed 225,000+ edits and bot scripts to Wikipedia since 2014. I also maintain a few side projects hosted here: [Games](https://karaman.dev/games) and [OR Tools](https://karaman.dev/or-araclari).
 
 <ul class="skill-tags">
   <li>Avionics</li><li>DO-178C DAL A</li><li>MISRA C</li><li>JSF C++</li><li>Embedded Systems</li><li>C / C++</li><li>Python</li><li>Qt</li><li>Test Automation</li><li>Systems Engineering</li><li>Xilinx Zynq</li><li>ARINC 429</li><li>MIL-STD-1553</li>

--- a/hakkimda.md
+++ b/hakkimda.md
@@ -18,7 +18,7 @@ Gündelik işim gereksinimler, MISRA ve JSF kurallarına göre yazılan C/C++ ko
 
 Hacettepe Üniversitesi Bilgisayar Yazılımı Mühendisliği yüksek lisansım ve İzmir Yüksek Teknoloji Enstitüsü Elektrik-Elektronik ve Haberleşme Mühendisliği lisansım var. Şu anda Sistem Mühendisliği alanında ikinci yüksek lisansıma devam ediyorum.
 
-İşin dışında [karaman.dev](https://karaman.dev/) ve [aviyonikyazilim.com](https://www.aviyonikyazilim.com/) üzerinde yazıyor, [GitHub](https://github.com/Mavrikant)'da kişisel projeler geliştiriyor ve 2014'ten bu yana Vikipedi'ye 225 binden fazla düzenleme ve bot betiğiyle katkı veriyorum.
+İşin dışında [karaman.dev](https://karaman.dev/) ve [aviyonikyazilim.com](https://www.aviyonikyazilim.com/) üzerinde yazıyor, [GitHub](https://github.com/Mavrikant)'da kişisel projeler geliştiriyor ve 2014'ten bu yana Vikipedi'ye 225 binden fazla düzenleme ve bot betiğiyle katkı veriyorum. Site üzerinde barındırdığım bazı yan projelerime de göz atabilirsiniz: [Oyunlar](https://karaman.dev/games) ve [OR Araçları](https://karaman.dev/or-araclari).
 
 <ul class="skill-tags">
   <li>Aviyonik</li><li>DO-178C DAL A</li><li>MISRA C</li><li>JSF C++</li><li>Gömülü sistemler</li><li>C / C++</li><li>Python</li><li>Qt</li><li>Test otomasyonu</li><li>Sistem mühendisliği</li><li>Xilinx Zynq</li><li>ARINC 429</li><li>MIL-STD-1553</li>


### PR DESCRIPTION
$(cat <<'EOF'
## Özet

Issue #82 kapsamında `karaman.dev/games` ve `karaman.dev/or-araclari` alt sitelerine uygun yerlerden linkler eklendi.

### Yapılan değişiklikler

- **Navbar** (`_includes/navbar.html`): "Projeler" dropdown menüsü eklendi; altında "Oyunlar" ve "OR Araçları" linkleri yer alıyor.
- **Footer** (`_includes/footer.html`): Mevcut "Bağlantılar" sütununun altına "Projeler" başlığı ve iki link eklendi.
- **about.md**: Kişisel projelerden bahseden paragrafa her iki alt siteye referans eklendi.
- **hakkimda.md**: Aynı paragrafın Türkçe karşılığına referans eklendi.

## Test planı

- [ ] Navbar'da "Projeler" dropdown'unun açıldığını ve her iki linkin doğru URL'e gittiğini kontrol et
- [ ] Footer'da "Projeler" başlığının ve linklerinin görüntülendiğini kontrol et
- [ ] About ve Hakkımda sayfalarında yeni linklerin çalıştığını doğrula
- [ ] Mobil görünümde navbar dropdown'unun düzgün açıldığını kontrol et

https://claude.ai/code/session_01SoTvgz3Kh1owCQjBmAMV5D
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoTvgz3Kh1owCQjBmAMV5D)_