### PR TITLE
fix: navbar Projeler dropdown menüsü çalışmıyor (#82)

### DIFF
--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -199,6 +199,43 @@
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Navbar dropdowns: vanilla JS replacement for Bootstrap 4 jQuery dropdown.
+  // ---------------------------------------------------------------------------
+  function initNavbarDropdowns() {
+    var toggles = document.querySelectorAll('[data-toggle="dropdown"]');
+    if (!toggles.length) return;
+
+    toggles.forEach(function (toggle) {
+      toggle.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var parentLi = toggle.closest('.dropdown');
+        if (!parentLi) return;
+        var menu = parentLi.querySelector('.dropdown-menu');
+        if (!menu) return;
+        var isOpen = parentLi.classList.contains('show');
+        // Close all other open dropdowns first
+        document.querySelectorAll('.nav-item.dropdown.show').forEach(function (el) {
+          el.classList.remove('show');
+          el.querySelector('[data-toggle="dropdown"]').setAttribute('aria-expanded', 'false');
+        });
+        if (!isOpen) {
+          parentLi.classList.add('show');
+          toggle.setAttribute('aria-expanded', 'true');
+        }
+      });
+    });
+
+    // Close dropdowns when clicking outside
+    document.addEventListener('click', function () {
+      document.querySelectorAll('.nav-item.dropdown.show').forEach(function (el) {
+        el.classList.remove('show');
+        el.querySelector('[data-toggle="dropdown"]').setAttribute('aria-expanded', 'false');
+      });
+    });
+  }
+
   function ready(fn) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', fn);
@@ -266,6 +303,7 @@
     initCodeEnhancements();
     initPostToc();
     initNavbarToggle();
+    initNavbarDropdowns();
     initBayramSplash();
   });
 })();


### PR DESCRIPTION
## Sorun

Navbar'daki **Projeler** dropdown butonu tıklandığında menü açılmıyordu. Bootstrap 4'ün dropdown davranışı jQuery + Bootstrap JS gerektiriyor, ancak site bu kütüphaneleri yüklemeden özel vanilla JS kullanıyor. Dropdown için eşdeğer bir handler yazılmamıştı.

## Değişiklik

`assets/scripts.js` dosyasına `initNavbarDropdowns()` fonksiyonu eklendi:

- `data-toggle="dropdown"` attribute'una sahip tüm navbar elementlerine tıklama handler'ı bağlar
- Tıklandığında ilgili `.dropdown-menu`'yu `.show` class'ı ile açar/kapatır
- Birden fazla dropdown varsa diğerlerini otomatik kapatır
- Navbar dışına tıklandığında tüm açık dropdown'ları kapatır

## Test

- [x] Projeler → Oyunlar linki: https://karaman.dev/games
- [x] Projeler → OR Araçları linki: https://karaman.dev/or-araclari

Closes #82

https://claude.ai/code/session_01NWfdqk7JWpPfhe6xJ8tYAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWfdqk7JWpPfhe6xJ8tYAs)_