### PR TITLE
ci: speed up workflows — native Ruby build, concurrency, paths filters

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -3,38 +3,35 @@ name: Build and Deploy to Github Pages
 on:
   push:
     branches:
-      - master  # Here source code branch is `master`, it could be other branch
+      - master
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
-      # Use GitHub Actions' cache to cache dependencies on servers
-      - uses: actions/cache@v5
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          path: |
-            .asdf/**
-            vendor/bundle
-          key: ${{ runner.os }}-cache-${{ hashFiles('**/cache.key') }}
-          restore-keys: |
-            ${{ runner.os }}-cache-
+          ruby-version: '3.2'
+          bundler-cache: true
 
-      # Use GitHub Deploy Action to build and deploy to Github
-      # For latest version: `jeffreytse/jekyll-deploy-action@master`
-      - uses: jeffreytse/jekyll-deploy-action@v0.7.0
+      - name: Build site
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          provider: 'github'         # Default is github
-          token: ${{ secrets.GITHUB_TOKEN }} # It's your Personal Access Token(PAT)
-          ssh_private_key: ''        # It's your SSH private key (SSH approach)
-          repository: ''             # Default is current repository
-          branch: 'gh-pages'         # Default is gh-pages for github provider
-          jekyll_src: './'           # Default is root directory
-          jekyll_cfg: '_config.yml'  # Default is _config.yml
-          jekyll_baseurl: ''         # Default is according to _config.yml
-          ruby_ver: ''               # Default is 3.2.0 version
-          bundler_ver: ''            # Default is compatible bundler version (~>2.5.0)
-          cname: ''                  # Default is to not use a cname
-          actor: ''                  # Default is the GITHUB_ACTOR
-          pre_build_commands: 'pacman -S imagemagick --noconfirm'     # Installing additional dependencies (Arch Linux)
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          publish_branch: gh-pages
+          cname: karaman.dev

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -2,7 +2,14 @@ name: Compress Images
 on:
   pull_request:
     branches: [ master ]
-    
+    paths:
+      - 'img/**'
+      - 'favicon.jpg'
+
+concurrency:
+  group: compress-images-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: calibreapp/image-actions

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,11 +14,29 @@ name: "CodeQL"
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '_posts/**'
+      - 'img/**'
+      - '**/*.md'
+      - 'CNAME'
+      - 'ads.txt'
+      - 'favicon.jpg'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    paths-ignore:
+      - '_posts/**'
+      - 'img/**'
+      - '**/*.md'
+      - 'CNAME'
+      - 'ads.txt'
+      - 'favicon.jpg'
   schedule:
     - cron: '34 8 * * 0'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,10 +5,20 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dependency-review:


### PR DESCRIPTION
Closes #85.

## Why

The deploy pipeline takes too long. Two main culprits:

1. **`jeffreytse/jekyll-deploy-action`** spins up an Arch Linux Docker container and reinstalls ImageMagick via `pacman` on every run.
2. **The cache key was broken** — `key: ${{ runner.os }}-cache-${{ hashFiles('**/cache.key') }}` hashed a file (`cache.key`) that doesn't exist, so the gem cache never hit.
3. No `concurrency` guards — rapid pushes accumulate redundant runs.
4. CodeQL ran on every push, including content-only changes (new posts, images) that don't affect JS/Ruby analysis.

## Changes

- **`build-jekyll.yml`**: replace the Arch-container deploy action with native `ruby/setup-ruby@v1` (`bundler-cache: true` keyed on `Gemfile`) + `peaceiris/actions-gh-pages@v4`. ImageMagick is preinstalled on `ubuntu-latest`, so `jekyll-favicon` works without the extra install step.
- **All workflows**: add `concurrency` with `cancel-in-progress: true` so new pushes cancel superseded runs.
- **`codeql-analysis.yml`**: `paths-ignore` for `_posts/**`, `img/**`, `**/*.md`, `CNAME`, `ads.txt`, `favicon.jpg`.
- **`calibreapp-image-actions.yml`**: only run when image files change.
- **`dependency-review.yml`**: only run when `Gemfile` / `package.json` (and lockfiles) change.

## Expected impact

- Build & deploy: ~1m41s → ~30–45s typical (cached gems + no container pull + no pacman install).
- CodeQL: skipped entirely on content-only commits.
- Compress Images / Dependency Review: skipped when unrelated files change.

## Test plan

- [ ] Merge → confirm `Build and Deploy` finishes faster and publishes `gh-pages` correctly (CNAME preserved, site loads at https://karaman.dev).
- [ ] Push a content-only commit → confirm CodeQL is skipped.
- [ ] Open a PR touching only `_posts/` → confirm `Compress Images` and `Dependency Review` are skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_016zqNEBhfZJTNa6xdXoRgzM)_