### PR TITLE
ci: install ImageMagick so jekyll-favicon build doesn't fail

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends imagemagick
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Follow-up to #86. The deploy job failed on master with:

```
MiniMagick::Error: You must have ImageMagick or GraphicsMagick installed
  from .../jekyll-favicon-1.1.0/lib/jekyll/favicon/utils/convert.rb:30:in `convert'
```

`ubuntu-latest` now points to ubuntu-24.04, which no longer ships ImageMagick preinstalled (it does on 22.04). `jekyll-favicon` uses `mini_magick`, so the build aborts during favicon generation.

## Fix

Install ImageMagick via apt before the Ruby setup step. Verified locally — `bundle exec jekyll build` completes after the install.

```yaml
- name: Install ImageMagick
  run: sudo apt-get update && sudo apt-get install -y --no-install-recommends imagemagick
```

## Test plan

- [ ] Merge → confirm `Build and Deploy` succeeds and `gh-pages` updates (site still serves at https://karaman.dev).


---
_Generated by [Claude Code](https://claude.ai/code/session_016zqNEBhfZJTNa6xdXoRgzM)_