### PR TITLE
Yeni yazı: `volatile` Yetmediğinde — Zynq-7000 Üzerinde C11 `_Atomic`, SCU ve Bellek Bariyerleri

### DIFF
--- a/_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md
+++ b/_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md
@@ -1,6 +1,6 @@
 ---
-title: "`volatile` Yetmediğinde: C11 `_Atomic` ve Bellek Bariyerleri"
-subtitle: "When `volatile` Is Not Enough: C11 `_Atomic` and Memory Barriers"
+title: "`volatile` Yetmediğinde: Zynq-7000 Üzerinde C11 `_Atomic`, SCU ve Bellek Bariyerleri"
+subtitle: "When `volatile` Is Not Enough on Zynq-7000: C11 `_Atomic`, the Snoop Control Unit, and Memory Barriers"
 background: "/img/posts/3.webp"
 date: '2026-05-29 09:00:00'
 layout: post
@@ -9,38 +9,50 @@ mermaid: true
 ---
 
 Gömülü dünyada en sık tekrarlanan yanılgılardan biri şudur: "değişkeni `volatile`
-yaparsam ISR ile main loop arasında güvenle paylaşabilirim". Bu cümle, yıllarca süren
-sahada-buluşan hata raporlarının, gece nöbetlerinin ve "ama lab'da çalışıyordu"
-ifadelerinin temel sebebidir. Yazının iddiası net: `volatile` ne C standardı ne de
-ARM mimarisi açısından bir eşzamanlılık (synchronization) ilkesi değildir; bunun için
-C11'in `<stdatomic.h>` başlığı, derleyici bariyerleri ve mimariye özgü bellek
-bariyerleri vardır.
+yaparsam iki Cortex-A9 çekirdeği veya PS ile PL arasında güvenle paylaşabilirim".
+Bu cümle, yıllarca süren sahada-buluşan hata raporlarının, gece nöbetlerinin ve
+"ama tek çekirdekte çalışıyordu" ifadelerinin temel sebebidir. Yazının iddiası net:
+`volatile` ne C standardı ne de ARMv7-A mimarisi açısından bir eşzamanlılık
+(synchronization) ilkesi değildir; bunun için C11'in `<stdatomic.h>` başlığı,
+derleyici bariyerleri ve mimariye özgü bellek bariyerleri vardır.
 
-Bu yazıda önce `volatile`'ın gerçekte neyi garanti edip etmediğini standart
-diliyle çıkaracağız, sonra Cortex-M4 üzerinde aynı operasyonun `volatile` ve
+Bu yazıda örnek platformu Zynq-7000 olarak seçiyoruz. Sebebi pedagojiktir: tek bir
+çipte hem klasik ARM SMP (iki Cortex-A9 çekirdeği, ortak L2 önbellek, SCU ile
+cache coherency), hem programlanabilir mantık (PL) tarafından gelen DMA, hem de
+ACP (Accelerator Coherency Port) üzerinden cache-snoop'lu PL transferleri vardır.
+Yani eşzamanlılık probleminin neredeyse bütün canlı varyasyonları aynı SoC'de
+karşımıza çıkar. (Renode ile bu sistemin nasıl simüle edileceğini daha önce
+[Renode ile Zynq7000 Simülasyonu](/2026/05/14/renode-ile-zynq7000-simulasyonu.html)
+yazısında ele almıştım; bu yazı onun yazılım eşzamanlılığı yanını tamamlar.)
+
+İlk önce `volatile`'ın gerçekte neyi garanti edip etmediğini standart diliyle
+çıkaracağız, sonra Cortex-A9 üzerinde aynı RMW operasyonunun `volatile` ve
 `_Atomic` versiyonlarının ürettiği assembly'yi yan yana koyup farkı göreceğiz.
 Ardından memory ordering meselesini (derleyici reordering + CPU reordering) ele
-alıp Cortex-M ailesinin tek çekirdek ve çok çekirdek senaryolarında ne gerekip ne
-gerekmediğine bakacağız. Son olarak Cortex-M0/M0+ ve M23'te `_Atomic`'in neden
-sessizce libatomic'e fallback ettiğini ve bunun gerçek maliyetini ortaya koyacağız.
+alıp Zynq-7000'in iki çekirdeği arasında SCU'nun, PS-PL arasında ACP'nin ve
+HP/GP portlarının ne yapıp ne yapmadığını ortaya koyacağız. Son olarak Cortex-A9
+özelinde `_Atomic`'in `LDREX/STREX` + `DMB ISH` ürettiği tipik kalıbı ve bunun
+shareability domain seçimine bağlı maliyetini inceleyeceğiz.
 
 ---
 
 ## Bir Olay Yeri: Kaybolan Artırımlar
 
-Aşağıdaki kod parçası, internette bulunan onlarca "tutorial"in özüdür:
+Aşağıdaki kod parçası, internette bulunan onlarca Zynq "tutorial"in özüdür.
+Zynq-7000 PS tarafında, TTC0 (Triple Timer Counter) Cortex-A9 #0'a kesme üretir;
+buna karşılık ana iş döngüsü Cortex-A9 #1'de koşmaktadır:
 
 ```c
-volatile uint32_t pulse_count;
+volatile uint32_t pulse_count;          /* OCM içinde paylaşılan */
 
-void TIM2_IRQHandler(void) {
-    if (TIM2->SR & TIM_SR_UIF) {
-        TIM2->SR &= ~TIM_SR_UIF;
-        pulse_count++;
-    }
+void TTC0_IRQHandler(void)              /* CPU0 üzerinde */
+{
+    XTtcPs_ClearInterruptStatus(&Ttc0, XTTCPS_IXR_INTERVAL_MASK);
+    pulse_count++;
 }
 
-void main_loop(void) {
+void main_loop_cpu1(void)               /* CPU1 üzerinde */
+{
     if (pulse_count >= 1000) {
         pulse_count = 0;
         trigger_event();
@@ -53,18 +65,20 @@ LED yanar, herkes mutlu. Tek bir şey hariç: birkaç saatlik koşumdan sonra
 `trigger_event()` çağrılma oranı saniyede tam olarak bir değildir — bazen 1.001,
 bazen 0.998. Birkaç gün sonra müşteri sahadan "sayım kayıyor" bildirir.
 
-Sebep, Cortex-M4'ün `pulse_count++` için ürettiği makine kodudur:
+Sebep iki katmanlıdır. İlk olarak Cortex-A9'un `pulse_count++` için ürettiği
+makine kodu:
 
 ```text
 ldr  r3, [r2]      ; r3 <- pulse_count
-adds r3, r3, #1    ; r3 = r3 + 1
+add  r3, r3, #1    ; r3 = r3 + 1
 str  r3, [r2]      ; pulse_count <- r3
 ```
 
-Bu üç talimatın **arasına** bir kesme girerse — örneğin `LDR` ile `STR` arasına —
-main loop'un sıfırlama yazısı veya başka bir ISR'ın artırması kaybolur. `volatile`
-derleyiciye "bu değişkeni cache'leme, her erişimi bellekten yap" der; **ama tek
-talimatla yap** demez. Çünkü demez ki: C dili `volatile` için zaten böyle bir şey
+Bu üç talimatın **arasına** CPU1'in okuması/yazısı girer — SCU L1 önbellek
+satırlarını koherent tutmaya çalışsa bile sıralama bozulur; bir tarafın
+artırması diğerinin sıfırlamasına çarpar. İkinci olarak `volatile` derleyiciye
+"bu değişkeni register'a cache'leme" der; ama "tek talimatla yap" demez ve
+"diğer çekirdeğe görünür kıl" hiç demez. C dili `volatile` için böyle bir şey
 söylemez.
 
 ---
@@ -87,14 +101,17 @@ Bu cümle iki şey söyler:
 Bu cümlenin söylemediği üç şey vardır ve hata kaynağı tam olarak burasıdır:
 
 1. **Atomicity yok.** Tek bir okuma veya yazmanın tek talimatta yapılacağına
-   dair garanti yoktur. `volatile uint64_t` Cortex-M üzerinde iki `LDR` ile
-   okunur; aralarına kesme girer.
+   dair garanti yoktur. `volatile uint64_t` Cortex-A9 üzerinde ya iki ardışık
+   `LDR` ya da `LDRD` ile okunur; `LDRD`'nin atomik olmadığı (iki
+   tek-word bus transferine bölünebildiği) ARM ARM tarafından açıkça belirtilir.
 2. **Diğer nesnelere göre sıralama yok.** `volatile a` ile yapılan okumanın,
    sıradan bir `b` değişkenine yapılan yazmadan önce bitmesi garanti değildir —
    derleyici onları rahatlıkla değiştirir.
-3. **Çekirdekler arası görünürlük yok.** Multi-core sistemde bir çekirdeğin
-   yaptığı `volatile` yazı, diğerinin önbelleğine kendiliğinden ulaşmaz; bunun
-   için cache maintenance + bellek bariyeri gerekir.
+3. **Çekirdekler arası görünürlük yok.** SMP sistemde bir çekirdeğin yaptığı
+   `volatile` yazı, diğerinin önbelleğine kendiliğinden ulaşmaz. Zynq-7000'de
+   SCU iki Cortex-A9'un L1 D-cache'lerini snoop ederek koherans sağlar; ama bu
+   ancak ilgili sayfa **inner shareable** olarak işaretliyse devreye girer ve
+   yine de **sıralama** bir bellek bariyeri olmadan garanti edilemez.
 
 Linus Torvalds ve Jonathan Corbet Linux çekirdeği belgesi
 [volatile-considered-harmful.rst](https://www.kernel.org/doc/html/next/process/volatile-considered-harmful.html)
@@ -117,10 +134,11 @@ durum makinesini iki çekirdek arasında senkronlamak — hiçbiri bu listede yo
 
 ---
 
-## Cortex-M4 Üzerinde Assembly Karşılaştırması
+## Cortex-A9 Üzerinde Assembly Karşılaştırması
 
-`arm-none-eabi-gcc 13.2` ile `-O2 -mcpu=cortex-m4 -mthumb` bayrakları altında iki
-fonksiyonu derleyip üretilen kodu karşılaştıralım.
+`arm-none-eabi-gcc 13.2` ile `-O2 -mcpu=cortex-a9 -marm` bayrakları altında iki
+fonksiyonu derleyip üretilen kodu karşılaştıralım. (Zynq-7000'in bare-metal SDK'sı
+olan Xilinx Vitis aynı toolchain'i kullanır.)
 
 ### Tek artırım — `volatile` versiyon
 
@@ -140,15 +158,17 @@ void v_inc(void) {
 v_inc:
     ldr     r3, .L2          ; r3 = &v_counter
     ldr     r2, [r3]         ; r2 = v_counter
-    adds    r2, r2, #1
+    add     r2, r2, #1
     str     r2, [r3]         ; v_counter = r2
     bx      lr
 .L2:
     .word   v_counter
 ```
 
-Üç bellek/aritmetik talimat. Kesme `LDR` ile `STR` arasına düşerse artırım
-kaybolur. Bu kodun atomik olduğuna dair hiçbir varsayım yapılamaz.
+Üç bellek/aritmetik talimat. Kesme `LDR` ile `STR` arasına düşerse veya CPU1
+araya aynı adrese yazarsa artırım kaybolur. Bu kodun atomik olduğuna dair
+hiçbir varsayım yapılamaz; bariyer talimatı da yok, dolayısıyla yazının diğer
+çekirdek tarafından ne zaman görüleceği de tanımsızdır.
 
 ### Aynı artırım — C11 `_Atomic` versiyon
 
@@ -163,13 +183,15 @@ void a_inc(void) {
 }
 ```
 
-Üretilen kod (aynı bayraklarla):
+Üretilen kod (aynı bayraklarla, `seq_cst` yerine `relaxed` seçilmesine rağmen
+SMP'de derleyici varsayılan olarak inner-shareable koruma da serpiştirir;
+relaxed örneğinde sadece RMW döngüsü görülür):
 
 ```text
 a_inc:
     ldr     r3, .L5
 1:  ldrex   r2, [r3]         ; exclusive load, monitor "watch" set
-    adds    r2, r2, #1
+    add     r2, r2, #1
     strex   r1, r2, [r3]     ; exclusive store; r1 = 0 başarı
     cmp     r1, #0
     bne     1b               ; başarısızsa baştan dene
@@ -178,27 +200,42 @@ a_inc:
     .word   a_counter
 ```
 
-Fark görünür: LDREX/STREX çifti, ARMv7-M'in **exclusive monitor**'ünü kullanarak
-"oku — değiştir — yaz" döngüsünü güvenli hale getirir. Eğer LDREX ile STREX
-arasında başka bir context (ISR, başka bir CPU) aynı adrese yazarsa STREX
-başarısız olur (`r1 = 1`), kod döngünün başına döner ve yeniden dener. Bu
-desen, ARM mimarisinde **LL/SC** (load-linked / store-conditional) ailesinden
+Aynı fonksiyonu `memory_order_seq_cst` ile yazarsanız (yani `atomic_fetch_add`
+varyantı) GCC RMW döngüsünün öncesine ve sonrasına `dmb ish` ekler:
+
+```text
+a_inc_seq:
+    ldr     r3, .L7
+    dmb     ish              ; önceki yazıların görünürlüğünü garanti et
+1:  ldrex   r2, [r3]
+    add     r2, r2, #1
+    strex   r1, r2, [r3]
+    cmp     r1, #0
+    bne     1b
+    dmb     ish              ; sonraki okumalar bunu görmeli
+    bx      lr
+.L7:
+    .word   a_counter
+```
+
+Fark görünür: LDREX/STREX çifti, ARMv7-A'nın **exclusive monitor**'ünü
+kullanarak "oku — değiştir — yaz" döngüsünü güvenli hale getirir. Eğer LDREX
+ile STREX arasında başka bir context (kesme veya CPU1) aynı adrese yazarsa
+STREX başarısız olur (`r1 = 1`), kod döngünün başına döner ve yeniden dener.
+Bu desen, ARM mimarisinde **LL/SC** (load-linked / store-conditional) ailesinden
 gelir ve karşılıklı dışlama (mutual exclusion) için temeldir.
 
-Cortex-M4 tek çekirdekli bir mimari olduğu için "diğer çekirdekten yazma"
-ihtimali yoktur; LDREX/STREX burada **yalnızca local monitor**'ü kullanır ve
-asıl koruma kesmeye karşıdır. ISR `STREX`'in çalışmasından önce devreye girerse
-local monitor temizlenir, STREX başarısız olur, döngü tekrar dener — sayım
-kaybolmaz.
-
-`-O2 -mcpu=cortex-m0` ile aynı kodu derlerseniz manzara değişir: ARMv6-M'de
-LDREX/STREX **yok**. GCC `a_inc` için `__atomic_fetch_add_4` çağrısı üretir;
-bu sembol libatomic'tedir. Libatomic'in M0+ implementasyonu tipik olarak
-`__sync` kütüphanesi arkasında PRIMASK'i set/clear ederek kesmeleri kapatır.
-Yani aynı kaynak kodu, hedefe göre 8 talimatlık inline döngüye veya bir
-fonksiyon çağrısı + IRQ disable/enable köprüsüne dönüşür. Bunu bilmeden kullanan
-ekipler, yumuşak gerçek-zaman sistemlerinde beklenmedik **kesme gecikmesi**
-(interrupt latency) ile karşılaşır.
+Zynq-7000 dual Cortex-A9 olduğu için bu örnek hayati önem taşır. Tek bir A9'da
+çalışan ISR-thread senaryosunda local monitor yeterli olurdu; ama burada CPU1'in
+de aynı adrese eriştiği bir SMP koşumumuz var. SCU (Snoop Control Unit) iki
+çekirdeğin exclusive monitor durumlarını **global olarak** koordine eder: CPU0
+`LDREX` çekip `STREX`'e gelmeden CPU1 `STREX` yaparsa, CPU0'ın monitor'ü
+temizlenir ve onun `STREX`'i başarısız olur. Bu garanti yalnızca ilgili sayfa
+**inner shareable** olarak işaretliyse geçerlidir; non-shareable sayfada SCU
+bypass olur ve LDREX/STREX iki çekirdek arasında **çalışmaz**. Linux ve bare-metal
+Xilinx BSP'leri OCM (On-Chip Memory) ile DDR'ı varsayılan olarak inner-shareable
+işaretler; ama elle yazılmış MMU tablolarında bu ayrıntı atlanırsa atomicity
+sessizce bozulur.
 
 ---
 
@@ -249,38 +286,42 @@ derleyicinin önünde engel yoktur.
 
 ### (2) CPU reordering
 
-CPU tarafı, mimariye göre çok farklıdır. ARM ailesi **weakly-ordered**'dir;
-yani CPU, veri bağımlılığı olmayan okuma ve yazmaları kendi başına yeniden
+CPU tarafı, mimariye göre çok farklıdır. ARMv7-A **weakly-ordered**'dır; yani
+CPU, veri bağımlılığı olmayan okuma ve yazmaları kendi başına yeniden
 sıralayabilir. Yayınlanan koşum sırası, yazıldığı sırayla aynı olmak zorunda
-değildir.
+değildir. Cortex-A9 üzerinde write buffer ve load forwarding bu yeniden
+sıralamayı her gün gerçekleştirir.
 
-ARM bunu üç bariyer talimatıyla kontrol eder:
+ARM bunu üç bariyer talimatıyla kontrol eder; her bariyer ayrıca bir
+**shareability domain** seçimiyle gelir:
 
 | Talimat | Anlamı | Tipik kullanım |
 |---|---|---|
 | `DMB` | Data Memory Barrier — bu noktadan önceki tüm bellek erişimleri sonrakilerden önce görünür olur | Spinlock al/bırak; çekirdekler arası paylaşılan veri |
-| `DSB` | Data Synchronization Barrier — DMB + öndeki tüm bellek erişimleri tamamlanmadan sonraki talimat başlamaz | Cache maintenance sonrası; MPU/MMU konfigürasyonu |
-| `ISB` | Instruction Synchronization Barrier — pipeline'ı temizler; sonraki talimatlar yeniden fetch edilir | Vector tablosu/SCB yapılandırma sonrası |
+| `DSB` | Data Synchronization Barrier — DMB + öndeki tüm bellek erişimleri tamamlanmadan sonraki talimat başlamaz | Cache maintenance sonrası; MMU TLB invalidate sonrası |
+| `ISB` | Instruction Synchronization Barrier — pipeline'ı temizler; sonraki talimatlar yeniden fetch edilir | Vector tablosu / system control register yapılandırma sonrası |
 
-Burada kritik bir nokta var: **Cortex-M ailesi tek çekirdeklidir** (klasik
-konfigürasyonda). Tek çekirdek üzerinde aynı çekirdeğin yaptığı yazıları kendi
-sonraki okumaları **her zaman** sıralı görür — bu mimari garantidir. O zaman
-DMB neden gerekir?
+Shareability domain seçenekleri:
 
-İki sebep:
+| Domain | Kapsama | Zynq-7000 karşılığı |
+|---|---|---|
+| `SY` (full system) | Bütün observers (CPU'lar + DMA + GPU vs.) | En geniş; konservatif |
+| `ISH` (inner shareable) | "Inner" domain — Zynq'te iki Cortex-A9 + L2 + ACP girişi | SMP veri paylaşımı için doğru seçim |
+| `OSH` (outer shareable) | Daha geniş outer domain | Zynq-7000'de pratikte ISH ile aynı sonucu verir |
+| `NSH` (non-shareable) | Yalnızca yerel çekirdek | Tek-CPU veri için |
 
-1. **DMA ile paylaşılan tampon.** CPU'nun yazısı henüz write buffer'da olabilir;
-   DMA controller'a "başla" yazmadan önce DSB ile yazıların gerçekten belleğe
-   ulaşması garantilenir.
-2. **Çok çekirdekli sistem.** Heterojen Cortex-M+M (STM32H7'nin M7+M4
-   konfigürasyonu, NXP i.MX RT1170 M7+M4 gibi) ve tüm Cortex-A SMP
-   sistemlerinde DMB şarttır; aksi halde diğer çekirdek yazıları yanlış sırayla
-   görür.
+GCC'nin Cortex-A9 hedefi için bir `release` veya `seq_cst` atomik operasyonu
+ürettiği bariyer **her zaman `dmb ish`**'dir. `__DMB()` makrosunu elle çağıran
+BSP kodu çoğunlukla `dmb sy` üretir; bu daha pahalıdır ama "ne yaptığını
+bilmeden de doğru" davranır. İki çekirdek SMP'sinde tipik olarak `ish` yeterli;
+DMA donanımı veya non-shareable bölgeyle alışveriş varsa `sy`'ye geçilir.
 
-Yani tek çekirdek Cortex-M üzerinde **thread + ISR** senaryosunda DMB
-**gereksizdir**. LDREX/STREX local monitor'ı yeterlidir. Bu, çok sayıda örnek
-kodun gereksiz `__DMB()` çağrısı içermesinin temel sebebidir — büyük ölçüde
-"copy-paste'tan multi-core kod" mirasıdır.
+Burada Zynq-7000'in iki çekirdeğinin **inner shareable domain** içinde
+olduğunu ve SCU'nun bu domain'de cache snoop yaptığını hatırlatmak gerekir.
+Yani `DMB ISH` "iki A9'a da görünürlük garanti et" demektir; bunu DDR sayfası
+inner-shareable ve cacheable işaretliyse derleyici ve donanım birlikte taşır.
+Sayfa yanlış işaretliyse `DMB ISH` ne yapacağını bilemez ve yarış aynen
+sürer — bu, BSP'lerde en sık atlanan sessiz hatalardan biridir.
 
 ---
 
@@ -336,109 +377,175 @@ tüketici tarafından **mutlaka** görülmüş olmalıdır." `volatile` ile bu g
 elde edilemez; çünkü `volatile` ne derleyici reordering'ini diğer değişkenlere
 karşı engeller, ne de CPU bariyeri üretir.
 
-Cortex-M4'te `release` store, derleyiciye bir `DMB` talimatı ürettirir
-(multi-core veya DMA paylaşımı varsa anlamlıdır; tek-core thread+ISR
-senaryosunda bile derleyici bariyeri kazancı vardır). Cortex-A SMP'de ise gerçek bir CPU bariyeri olur.
+Cortex-A9 SMP'de `release` store derleyiciye `DMB ISH` ürettirir; bu hem
+derleyici bariyeridir hem de SCU'nun snoop kuyruğunun boşaltılmasını tetikler.
+Bu bariyer atılırsa CPU1 mesajı asla görmez, ya da buffer içeriğinden önce
+flag'i görür ve **mantıken imkânsız** bir hatayla karşılaşır. Zynq-7000'in PS
+tarafında çalışan bir Linux veya FreeRTOS SMP yapılandırması, atomik
+operasyonların `DMB ISH` üretip üretmediğini sürekli denetler — kernel'in
+spin_lock implementasyonu da aynı kalıp üzerinedir.
 
 ---
 
-## Tek Çekirdek vs Çok Çekirdek: Karar Matrisi
+## Zynq-7000 Senaryoları İçin Karar Matrisi
 
 | Senaryo | Atomicity | Derleyici bariyeri | CPU bariyeri | Doğru araç |
 |---|---|---|---|---|
-| Tek `volatile uint8_t` bayrağı, ISR yazar, main okur, Cortex-M | `uint8_t` zaten tek talimat, OK | Aynı değişken için OK | Tek-core: gereksiz | `volatile` *yetebilir* — ama `_Atomic` daha güvenli |
-| `pulse_count++`, ISR + main, Cortex-M4 | LDREX/STREX şart | Var | Gereksiz | `atomic_fetch_add_explicit(..., relaxed)` |
-| Üretici-tüketici buffer, ISR + main, Cortex-M4 | flag için OK | Şart | Gereksiz (single-core) | `atomic_store/load_explicit(..., release/acquire)` |
-| DMA tampon, CPU yazar, DMA okur | Yazı OK | Şart | `DSB` şart (DMA başlatma öncesi) | `__DSB()` + `volatile` register |
-| Dual M7 / Cortex-A SMP, paylaşılan kuyruk | Şart | Şart | `DMB` şart | `_Atomic` + `release/acquire` |
-| Bellek-eşlenikli register (UART, GPIO) | Genelde tek talimat | Şart | Mimariye göre | `volatile` (atomic değil, **donanım yan etkisi**) |
+| `volatile uint8_t` bayrağı, CPU0 ISR yazar, CPU0 main okur | `uint8_t` tek `STRB`, OK | OK | Aynı CPU: gereksiz | `_Atomic` yine daha güvenli (kod yarın CPU1'e taşınabilir) |
+| `pulse_count++`, CPU0 ISR + CPU0 main, aynı çekirdek | LDREX/STREX local monitor | Var | Gereksiz | `atomic_fetch_add_explicit(..., relaxed)` |
+| `pulse_count++`, CPU0 ISR + CPU1 main (SMP) | LDREX/STREX + SCU snoop şart | Şart | `DMB ISH` şart | `atomic_fetch_add_explicit(..., seq_cst)` |
+| Üretici-tüketici buffer, CPU0 → CPU1, OCM/DDR (cacheable, inner-shareable) | flag için OK | Şart | `DMB ISH` çifti | `release/acquire` çifti |
+| PS → PL DMA, GP/HP port (non-coherent) | Yazı OK | Şart | `DSB SY` + L1/L2 clean şart | `Xil_DCacheFlushRange()` + `__DSB()` + `volatile` register |
+| PS → PL DMA, ACP üzerinden (coherent) | Yazı OK | Şart | Cache clean **gereksiz**; `DMB SY` yine de | `volatile` register; ACP master 64-byte burst |
+| PL → PS DMA, GP/HP port | DMA bitince L1/L2 invalidate şart | Şart | `DSB SY` invalidate öncesi | `Xil_DCacheInvalidateRange()` + bariyer |
+| Bellek-eşlenikli register (UART, GPIO, TTC) | Genelde tek talimat | Şart | Strongly-ordered sayfada otomatik | `volatile` (atomic değil, **donanım yan etkisi**) |
 
 Tek satıra indirgersek: **Kayıt (register) erişiminde `volatile`; paylaşılan
-veri erişiminde `_Atomic`.** Bu iki kavram aynı isim değildir, aynı mekanizma
-hiç değildir.
+veri erişiminde `_Atomic`; PL ile DMA paylaşımında cache maintenance + DSB
+veya ACP.** Bu üç kavram aynı isim değildir, aynı mekanizma hiç değildir.
 
 ---
 
-## Cortex-M0/M0+ ve M23: `_Atomic`'in Sessiz Bedeli
+## Zynq-7000'in Üç Koherans Bölgesi
 
-ARMv6-M (M0, M0+, M1) ve ARMv8-M Baseline (M23) ailesi exclusive monitor
-içermez. Bu hedeflerde GCC `<stdatomic.h>`'i koruyabilmek için libatomic
-kullanır. Tipik bir `atomic_fetch_add` çağrısı şuna benzer:
+Zynq-7000'i diğer ARM SoC'lardan ayıran şey, PS ile PL arasında üç farklı
+koherans davranışı sergileyen yolun bulunmasıdır. Her birinin `volatile` /
+`_Atomic` / cache bariyeri sorumluluğu farklıdır.
 
-```text
-a_inc:
-    push    {r4, lr}
-    movs    r2, #5            ; memory_order_seq_cst (5)
-    movs    r1, #1            ; ekleme miktarı
-    ldr     r0, .L3           ; &a_counter
-    bl      __atomic_fetch_add_4
-    pop     {r4, pc}
-.L3:
-    .word   a_counter
+```mermaid
+flowchart LR
+    subgraph PS["PS — Processing System"]
+        A9_0["Cortex-A9 #0<br/>L1 D$ + I$"]
+        A9_1["Cortex-A9 #1<br/>L1 D$ + I$"]
+        SCU["SCU<br/>(Snoop Control Unit)"]
+        L2["L2 cache<br/>(PL310, 512 KB)"]
+        OCM["OCM<br/>(256 KB)"]
+        A9_0 --> SCU
+        A9_1 --> SCU
+        SCU --> L2
+        SCU --> OCM
+    end
+    subgraph PL["PL — Programmable Logic"]
+        IP1["IP / DMA Master"]
+        IP2["IP / DMA Master"]
+        IP3["IP / DMA Master"]
+    end
+    L2 --> DDR["DDR<br/>controller"]
+    IP1 -. "ACP<br/>(coherent)" .-> SCU
+    IP2 -. "HP0-3<br/>(non-coherent)" .-> DDR
+    IP3 -. "GP0-1<br/>(slave / control)" .-> SCU
 ```
 
-Fonksiyon çağrısının arkasında, libatomic'in M0+ implementasyonu PRIMASK'i
-kaydeder, kesmeleri kapatır, RMW yapar, PRIMASK'i geri yükler. Bu yaklaşımın
-iki bedeli vardır:
+**1. SCU + inner-shareable bölge.** İki Cortex-A9'un L1 D-cache'leri ve L2
+cache, SCU tarafından otomatik snoop edilir. MMU sayfasını `Normal Memory,
+Cacheable, Inner-Shareable` olarak işaretlerseniz, CPU0'ın yazısı CPU1'in
+okumasında otomatik olarak doğru değeri verir; arada **manuel cache flush
+gerekmez**. SCU bir cache satırına başka çekirdeğin yazdığını fark eder, ilgili
+satırı diğer çekirdekte invalidate eder, yeni veriyi gerektiğinde okur.
+LDREX/STREX da bu domain üzerinde global olarak çalışır.
 
-1. **Kesme gecikmesi.** Critical section, dış fonksiyon çağrısı + iki PRIMASK
-   manipülasyonu boyunca aktiftir. Yumuşak gerçek-zaman sistemlerde her atomik
-   operasyon ~10-20 cycle pin daha yüksek interrupt jitter doğurur.
-2. **Link zamanı bağımlılığı.** Bare-metal projelerde libatomic her zaman link
-   edilemez; `-latomic` ihtiyacı vardır ve newlib-nano ile çakışmalar olabilir.
+İşte gizli tuzak: SCU yalnızca **Inner Shareable** işaretli sayfalarda devreye
+girer. Yanlış sayfa attribute (örn. "Strongly Ordered" veya "Device") veya
+non-shareable cacheable sayfa, snoop'un dışında kalır. Bu durumda `_Atomic`
+hatasız derlenir, LDREX/STREX talimatları üretilir, ama çekirdekler arasında
+hiçbir koherans yoktur — her biri kendi L1'ine yazar, diğeri yanlış değeri
+okur. Xilinx'in `xil_mmu` BSP'si DDR'ı varsayılan olarak doğru işaretler; ama
+özel `Xil_SetTlbAttributes()` çağrıları yapan kod bunu kolayca bozar.
 
-Bu nedenle gömülü ekipler ARMv6-M hedeflerinde sık sık alternatif bir yol
-seçer: kritik bölge etrafında elle `__disable_irq()`/`__enable_irq()` veya
-ARM'ın "atomic register access" pattern'i. Bu seçim, "küçük çip, küçük araç
-seti" pragmatizmidir; ama gerçek `volatile` ile aynı şey değildir — sadece
-implementasyon detayıdır.
+**2. ACP (Accelerator Coherency Port) — koherent PL→PS yolu.** ACP, PL'deki
+bir DMA master'ın isteklerini SCU'ya bağlar. ACP üzerinden PL'nin yaptığı
+yazı L1/L2 üzerinde snoop edilir ve CPU'lar manuel cache invalidate çağırmadan
+güncel veriyi okur. ACP'nin verimli çalışması için iki kısıt vardır:
+
+- AxCACHE/AxPROT sinyalleri "cacheable + bufferable" işaretlenmelidir
+  (Xilinx tipik olarak `0b1111` önerir).
+- Transfer büyüklüğü tercihen tam bir L1 cacheline (64 byte) olmalıdır; küçük
+  transferler SCU'da kuyruk oluşturur ve performansı düşürür.
+
+ACP'nin pratik faydası, **ARM üzerinde son derece pahalı olan cache
+flush/invalidate çağrılarını tamamen ortadan kaldırmasıdır.** Linux'ta
+`Xil_DCacheFlushRange()` 4 KB için bile çift haneli mikrosaniye alırken, ACP
+yolu transferi cache'in içine sokar.
+
+**3. HP/GP portları — non-coherent PL→PS yolu.** HP (High Performance) ve GP
+(General Purpose) AXI portları DDR'a doğrudan erişir; SCU bypass olur. Burada
+yazılım sorumlulukları net biçimde değişir:
+
+- **CPU yazdı, PL okuyacak:** `Xil_DCacheFlushRange()` ile L1/L2'yi DDR'a
+  geri yaz, ardından `__DSB()` ile yazıların gerçekten controller'a ulaşmasını
+  bekle, sonra PL'e "başla" sinyali ver.
+- **PL yazdı, CPU okuyacak:** PL transferin bittiğini bildirdikten sonra
+  `Xil_DCacheInvalidateRange()` ile L1/L2'deki bayat satırları at, sonra oku.
+  Bu çağrı içeriğinde DSB barındırır.
+
+Bu noktada `volatile`'ın tek doğru kullanımı, PL'in **status/control
+register'ına** erişen pointer'dır. Tampon belleğine `volatile` koymak ne cache
+maintenance'ı yapar ne de tutarlı bir senkronizasyon kurar; sadece derleyici
+optimizasyonunu bastırır ve sorunu gizler.
+
+Sonuç pratiktir: Zynq-7000'de bir PL IP'sini tasarlarken **ACP'yi tercih
+edebiliyorsanız edin** — yazılım tarafı çok daha basitleşir. Edemiyorsanız
+cache maintenance + bariyer disiplininize kanıtlanabilir biçimde uyun;
+"unutmadık herhalde" iyi bir mühendislik argümanı değildir.
 
 ---
 
-## Sık Yapılan Beş Hata
+## Zynq-7000'de Sık Yapılan Altı Hata
 
-1. **`volatile` bayrak ile spinlock kurmak.** `while (locked) {}` ile beklemek
-   atomik gibi görünse de iki çekirdek arasında yarış vardır. Doğrusu:
-   `atomic_flag_test_and_set_explicit(&lock, memory_order_acquire)`.
-2. **`_Atomic struct` ile büyük yapı kullanmak.** C11 izin verir, ama
-   derleyici `sizeof` belirli eşiklerin üstünde tüm yapıyı libatomic'in lock
-   tablosuna yönlendirir. Sonuç: her erişim hash-locked. Büyük yapıları açıkça
-   bir mutex ile koruyun.
-3. **64-bit `_Atomic` ARMv7-M üzerinde.** LDREXD/STREXD var ama derleyici hep
-   üretmez; -O ayarlarına göre libatomic'e düşülebilir. `__atomic_always_lock_free
-   (8, 0)` ile derleme zamanında kontrol edin.
+1. **`volatile` bayrak ile spinlock kurmak.** Cortex-A9 SMP'de `while (locked)
+   {}` ile beklemek iki çekirdek arasındaki yarışa karşı bir şey yapmaz.
+   Doğrusu: `atomic_flag_test_and_set_explicit(&lock, memory_order_acquire)`.
+   GCC bunu `LDREX`/`STREX` + `DMB ISH` ile derler ve SCU üzerinden CPU1'e
+   doğru sırada görünür.
+2. **`_Atomic struct` ile büyük yapı kullanmak.** C11 izin verir, ama derleyici
+   `sizeof` belirli eşiklerin üstünde (Cortex-A9'da tipik olarak 8 byte'tan
+   büyük) tüm yapıyı libatomic'in global lock tablosuna yönlendirir. Sonuç:
+   her erişim hash-locked. Büyük yapıları açıkça bir mutex ile koruyun.
+3. **64-bit `_Atomic` üzerinde LDREXD/STREXD varsayımı.** Cortex-A9 LDREXD ve
+   STREXD'yi destekler, ama derleyici her zaman üretmez; `-O0` veya hizalama
+   problemi varsa libatomic'e düşülür. `__atomic_always_lock_free(8, 0)` ile
+   derleme zamanında kontrol edin.
 4. **`memory_order_consume` kullanmak.** Standart tanımı pratik derleyicilerin
    doğru uygulayamadığı kadar karmaşıktır; tüm yaygın derleyiciler bunu
    `acquire`'a yükseltir. C++ komitesi 2017'den beri yeniden tanımlamayı
    tartışıyor. Kullanmayın.
-5. **Cortex-M tek-core'da gereksiz `__DMB()` serpiştirmek.** Performans
-   maliyeti küçük ama sıfır değil, ve daha kötüsü kodun çok-core'a taşındığı
-   yanılgısını yaratır. Asıl koruma `_Atomic` + uygun memory order'dır;
-   bariyer talimatı bunun **yan ürünüdür**.
+5. **DMA tamponuna `volatile` koyup cache yönetimini atlamak.** Bu, gömülü
+   dünyasındaki en yaygın silent-corruption sebebidir. `volatile` derleyiciye
+   "register'a cache'leme" der; cache controller'a "L1/L2'yi flush et" demez.
+   PS↔PL DMA için ya ACP yolunu seçin ya da `Xil_DCacheFlushRange` /
+   `Xil_DCacheInvalidateRange` çağrılarını ihmal etmeyin.
+6. **MMU sayfa attribute'unu yanlış kurup `_Atomic`'in sessizce çökmesine izin
+   vermek.** SCU sadece **Inner Shareable + Cacheable** sayfalarda snoop yapar.
+   "Strongly Ordered" veya non-shareable cacheable işaretli bir bölgede LDREX/
+   STREX iki çekirdek arasında çalışmaz; her CPU kendi yarışını kaybeder.
 
 ---
 
-## Bir Karar Akışı
+## Zynq-7000 İçin Karar Akışı
 
 ```mermaid
 flowchart TD
-    A[Paylaşılan veriye erişiyorum] --> B{Donanım registerı mı?}
-    B -- Evet --> C[volatile pointer kullan,<br/>gerekirse __DSB/__DMB]
-    B -- Hayır --> D{Tek bir okuma veya yazma mı?}
-    D -- Evet --> E{Doğal hizalı ve native genişlik mi?}
-    E -- Evet --> F[_Atomic + relaxed yeterli<br/>Donanım tek talimat üretir]
-    E -- Hayır --> G[_Atomic kullan, libatomic'e düşebilir]
-    D -- Hayır, RMW --> H[atomic_fetch_* kullan]
+    A[Paylaşılan veriye erişiyorum] --> B{Hedef nedir?}
+    B -- "PS register PL register UART/GPIO/TTC" --> C[volatile pointer kullan,<br/>strongly-ordered sayfa<br/>__DSB gerekirse]
+    B -- "PS RAM PS RAM iki CPU paylaşıyor" --> D{Tek okuma/yazma mı?}
+    B -- "PL DMA tampon" --> M{ACP kullanılıyor mu?}
+    D -- Evet --> E{Doğal hizalı native genişlik mi?}
+    E -- Evet --> F[_Atomic + relaxed<br/>SCU snoop devrede<br/>sayfa: Inner Shareable]
+    E -- Hayır --> G[_Atomic + uygun memory_order]
+    D -- Hayır RMW --> H[atomic_fetch_* kullan<br/>seq_cst varsayılan,<br/>kasıtlıysa relaxed]
     H --> I{Sıralama gerekiyor mu?}
-    I -- Hayır, sadece sayaç --> J[relaxed]
-    I -- Üretici-tüketici --> K[release/acquire çifti]
-    I -- Tam sıralama --> L[seq_cst — pahalı, gerçekten gerekli mi?]
+    I -- Sadece sayaç --> J[relaxed]
+    I -- Üretici-tüketici --> K[release/acquire çifti<br/>DMB ISH otomatik]
+    I -- Tam sıralama --> L[seq_cst — pahalı,<br/>gerçekten gerekli mi?]
+    M -- Evet --> N[ACP master<br/>cache flush GEREKMEZ<br/>64-byte burst tercih edin]
+    M -- Hayır HP/GP --> O[CPU→PL: Xil_DCacheFlushRange + DSB<br/>PL→CPU: Xil_DCacheInvalidateRange]
 ```
 
-Bu akış, "önce mimari, sonra araç" disiplinini dayatır. `volatile`'a karar
-verirken sorduğumuz tek soru "bu adres bir cihaz registerı mı?" olmalıdır.
-Bir `_Atomic`'e karar verirken sorduğumuz soru "bu veriyi başka bir context
-de görüyor mu, ve görmesi gereken sırada görmek zorunda mı?" olmalıdır.
+Bu akış, "önce mimari, sonra araç" disiplinini dayatır. Zynq-7000'de doğru
+soru sırası: (1) hedef nerede yaşıyor — PS register, PS RAM, PL DMA tampon?
+(2) eğer PS RAM ise, sayfa attribute'u doğru mu (Inner Shareable + Cacheable)?
+(3) eğer PL DMA ise, ACP yolu açık mı? `volatile` cevabı sadece "PS veya PL
+register" branşında doğrudur; gerisi `_Atomic` veya cache maintenance işidir.
 
 ---
 
@@ -453,14 +560,15 @@ yazı ARM'da gerçekten tek `STRB` ile yapılır, dolayısıyla atomicity sorunu
   talimattır.
 - Yazma diğer değişkenlerle sıralama garanti **etmez.** Üretici-tüketici
   senaryosunda buffer yazıları bayraktan sonra görünebilir.
-- Multi-core sistemde diğer çekirdek bu yazıyı kendi cache'i nedeniyle eski
-  görebilir.
+- Zynq-7000 gibi SMP sistemde CPU1 bu yazıyı kendi L1 cache'i nedeniyle eski
+  görebilir; sayfa Inner Shareable işaretli değilse SCU snoop bile devreye
+  girmez.
 
 Yani "tek baytlık `volatile` yeterli" cümlesi, "kesinlikle bir bayrak okuyup
 yazıyorum, başka değişkene bağlamıyorum, tek çekirdekteyim" kısıtının altında
-doğrudur. Bu kısıtın hayatınızdaki ömrü kısadır; kodun yarın multi-core'a
-taşınma ihtimali yüksektir. Doğru alışkanlık baştan `_Atomic` yazmaktır;
-ek maliyeti tek-core hedefte çoğu durumda sıfırdır.
+doğrudur. Zynq-7000'de bu kısıtın hayatınızdaki ömrü kısadır; bayrak bugün
+sadece CPU0'da kullanılıyor olsa bile yarın CPU1'e taşınma ihtimali yüksektir.
+Doğru alışkanlık baştan `_Atomic` yazmaktır; ek maliyet çoğu durumda görünmez.
 
 ---
 
@@ -474,8 +582,11 @@ arasında değer korumada yeri vardır. Hiçbirinin adı "eşzamanlılık" deği
 Eşzamanlılık kelimesi C dilinde C11 ile birlikte gelmiştir: `_Atomic` türleri,
 `<stdatomic.h>` fonksiyonları, ve `memory_order` enum'u. Bunlar atomicity,
 sıralama ve çekirdekler arası görünürlüğü tek bir tutarlı modelde birleştirir.
-ARM mimarisi üzerinde bu modelin altyapısı LDREX/STREX, DMB/DSB/ISB ve
-ARMv8'in load-acquire/store-release talimatlarıyla sağlanır.
+ARMv7-A üzerinde — Zynq-7000'in PS tarafı — bu modelin altyapısı LDREX/STREX,
+DMB/DSB/ISB (özellikle ISH shareability domain'i) ve SCU snoop coherency
+mekanizmasıyla sağlanır. PS ile PL arasında ise üç ayrı yol vardır: SCU'ya
+bağlanan ACP koherent, HP/GP portları non-koherent. Hangisini seçtiğiniz
+yazılım tarafının cache disiplininin sınırını belirler.
 
 Yazılım emniyet kritik olduğunda ve özellikle DO-178C DAL-A gibi seviyelerde
 bu ayrımın belgelenmesi de önemlidir. Statik analiz araçları (Polyspace,
@@ -484,9 +595,12 @@ olarak işaretler ve haklıdır. Standart sürecin "MC/DC kapsama" gibi sıkı k
 varsa, eşzamanlılık modelinin doğru olduğunu kanıtlamak da aynı disiplinin
 parçasıdır.
 
-Bir sonraki ISR sayacınızı `volatile uint32_t` ile yazmadan önce iki kere
-düşünün. `atomic_uint` ek bir satır değildir; arkasında yarım yüzyıllık
-mimari kararların ve bir dil standardının düşünülmüş yanıtı vardır.
+Bir sonraki Zynq projenizde CPU0 ile CPU1 arasında bir sayaç paylaşmadan önce
+iki kere düşünün. `volatile uint32_t` yazıp `__DMB()` serpiştirmek "her şey
+gözüm önündeyken yarış olamaz" hissi verir, ama mimari bu hissi onaylamaz.
+`atomic_uint` ek bir satır değildir; arkasında C11 standardının, ARMv7-A bellek
+modelinin ve SCU'nun düşünülmüş yanıtı vardır. Doğru aracı kullanın; yarın
+sahaya çıkmış sistemde hata avlayan siz olacaksınız.
 
 ---
 
@@ -502,10 +616,17 @@ mimari kararların ve bir dil standardının düşünülmüş yanıtı vardır.
 - [LWN — The trouble with volatile (Jonathan Corbet, 2007)](https://lwn.net/Articles/233479/)
 - [Embedded.com — Jack Ganssle, "C keywords: Don't flame out over
   volatile"](https://www.embedded.com/c-keywords-dont-flame-out-over-volatile/)
-- ARM Architecture Reference Manual ARMv7-M, DDI 0403E.e — Bölüm A3.4
-  ("Synchronization and semaphores") ve A4.5 ("Memory barriers").
-- ARM Architecture Reference Manual ARMv6-M, DDI 0419E.
+- ARM Architecture Reference Manual ARMv7-A and ARMv7-R, DDI 0406C.d — Bölüm
+  A3.4 ("Synchronization and semaphores") ve A3.8 ("Memory barriers").
+- [ARM Cortex-A9 MPCore Technical Reference Manual, DDI 0407](https://www.cl.cam.ac.uk/research/srg/han/ACS-P35/zynq/Cortex-A9-MPCore-TRM.pdf)
+  — özellikle SCU davranışı ve LDREX/STREX'in MPCore'da çalışma şekli.
+- Xilinx UG585, "Zynq-7000 SoC Technical Reference Manual" — Bölüm 3 (PS),
+  Bölüm 5 (Interconnect), Bölüm B.4 (ACP).
+- [AMD/Xilinx Wiki — Zynq-7000 AP SoC Performance: Ethernet Packet Inspection,
+  Redirecting Headers to PL and Cache Tech Tip](https://xilinx-wiki.atlassian.net/wiki/display/A/Zynq-7000+AP+SoC+-+Performance+-+Ethernet+Packet+Inspection+-+Bare+Metal+-+Redirecting+Headers+to+PL+and+Cache+Tech+Tip)
+- [Xillybus Forum — Guidance for using the ACP port on the Zynq SoC](https://forum.xillybus.com/viewtopic.php?f=4&t=415)
+- [SLAC Confluence — Zynq-7000 notes (SCU, coherency, atomic instructions)](https://confluence.slac.stanford.edu/display/CCI/Zynq-7000+notes)
 - Hans-J. Boehm, "Threads Cannot Be Implemented as a Library", PLDI 2005 — C
   bellek modelinin neden dil seviyesinde gerekli olduğunu açıklayan kurucu makale.
-- [ARM Community — LDREX/STREX on M3, M4, M7](https://community.arm.com/support-forums/f/architectures-and-processors-forum/10361/ldrex-strex-on-the-m3-m4-m7)
-- [SoC.org — How to implement atomic operations on multi-core Cortex-M0/M0+?](https://s-o-c.org/how-to-implement-atomic-operations-on-multi-core-cortex-m0-m0/)
+- [Renode ile Zynq7000 Simülasyonu](/2026/05/14/renode-ile-zynq7000-simulasyonu.html)
+  — bu yazıdaki SMP koşumlarını simülatörde yeniden üretmek için.

--- a/_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md
+++ b/_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md
@@ -39,8 +39,9 @@ shareability domain seçimine bağlı maliyetini inceleyeceğiz.
 ## Bir Olay Yeri: Kaybolan Artırımlar
 
 Aşağıdaki kod parçası, internette bulunan onlarca Zynq "tutorial"in özüdür.
-Zynq-7000 PS tarafında, TTC0 (Triple Timer Counter) Cortex-A9 #0'a kesme üretir;
-buna karşılık ana iş döngüsü Cortex-A9 #1'de koşmaktadır:
+Zynq-7000 PS tarafında AMP modunu varsayalım: iki çekirdek aynı OCM bloğunu
+paylaşıyor; TTC0 (Triple Timer Counter) Cortex-A9 #0'a kesme üretir; ana iş
+döngüsü Cortex-A9 #1'de koşmaktadır:
 
 ```c
 volatile uint32_t pulse_count;          /* OCM içinde paylaşılan */
@@ -183,9 +184,8 @@ void a_inc(void) {
 }
 ```
 
-Üretilen kod (aynı bayraklarla, `seq_cst` yerine `relaxed` seçilmesine rağmen
-SMP'de derleyici varsayılan olarak inner-shareable koruma da serpiştirir;
-relaxed örneğinde sadece RMW döngüsü görülür):
+Üretilen kod (aynı bayraklarla, `memory_order_relaxed` ile — yani derleyici
+yalnızca atomicity sağlamak zorunda, sıralama bariyeri eklememeli):
 
 ```text
 a_inc:
@@ -387,25 +387,6 @@ spin_lock implementasyonu da aynı kalıp üzerinedir.
 
 ---
 
-## Zynq-7000 Senaryoları İçin Karar Matrisi
-
-| Senaryo | Atomicity | Derleyici bariyeri | CPU bariyeri | Doğru araç |
-|---|---|---|---|---|
-| `volatile uint8_t` bayrağı, CPU0 ISR yazar, CPU0 main okur | `uint8_t` tek `STRB`, OK | OK | Aynı CPU: gereksiz | `_Atomic` yine daha güvenli (kod yarın CPU1'e taşınabilir) |
-| `pulse_count++`, CPU0 ISR + CPU0 main, aynı çekirdek | LDREX/STREX local monitor | Var | Gereksiz | `atomic_fetch_add_explicit(..., relaxed)` |
-| `pulse_count++`, CPU0 ISR + CPU1 main (SMP) | LDREX/STREX + SCU snoop şart | Şart | `DMB ISH` şart | `atomic_fetch_add_explicit(..., seq_cst)` |
-| Üretici-tüketici buffer, CPU0 → CPU1, OCM/DDR (cacheable, inner-shareable) | flag için OK | Şart | `DMB ISH` çifti | `release/acquire` çifti |
-| PS → PL DMA, GP/HP port (non-coherent) | Yazı OK | Şart | `DSB SY` + L1/L2 clean şart | `Xil_DCacheFlushRange()` + `__DSB()` + `volatile` register |
-| PS → PL DMA, ACP üzerinden (coherent) | Yazı OK | Şart | Cache clean **gereksiz**; `DMB SY` yine de | `volatile` register; ACP master 64-byte burst |
-| PL → PS DMA, GP/HP port | DMA bitince L1/L2 invalidate şart | Şart | `DSB SY` invalidate öncesi | `Xil_DCacheInvalidateRange()` + bariyer |
-| Bellek-eşlenikli register (UART, GPIO, TTC) | Genelde tek talimat | Şart | Strongly-ordered sayfada otomatik | `volatile` (atomic değil, **donanım yan etkisi**) |
-
-Tek satıra indirgersek: **Kayıt (register) erişiminde `volatile`; paylaşılan
-veri erişiminde `_Atomic`; PL ile DMA paylaşımında cache maintenance + DSB
-veya ACP.** Bu üç kavram aynı isim değildir, aynı mekanizma hiç değildir.
-
----
-
 ## Zynq-7000'in Üç Koherans Bölgesi
 
 Zynq-7000'i diğer ARM SoC'lardan ayıran şey, PS ile PL arasında üç farklı
@@ -449,23 +430,29 @@ girer. Yanlış sayfa attribute (örn. "Strongly Ordered" veya "Device") veya
 non-shareable cacheable sayfa, snoop'un dışında kalır. Bu durumda `_Atomic`
 hatasız derlenir, LDREX/STREX talimatları üretilir, ama çekirdekler arasında
 hiçbir koherans yoktur — her biri kendi L1'ine yazar, diğeri yanlış değeri
-okur. Xilinx'in `xil_mmu` BSP'si DDR'ı varsayılan olarak doğru işaretler; ama
-özel `Xil_SetTlbAttributes()` çağrıları yapan kod bunu kolayca bozar.
+okur. Xilinx standalone BSP'nin `translation_table.S` dosyası DDR'ı varsayılan
+olarak Normal, Cacheable, Shareable işaretler; ama runtime'da
+`Xil_SetTlbAttributes()` çağırarak attribute değiştiren kod bu garantiyi kolayca
+bozar.
 
 **2. ACP (Accelerator Coherency Port) — koherent PL→PS yolu.** ACP, PL'deki
 bir DMA master'ın isteklerini SCU'ya bağlar. ACP üzerinden PL'nin yaptığı
 yazı L1/L2 üzerinde snoop edilir ve CPU'lar manuel cache invalidate çağırmadan
 güncel veriyi okur. ACP'nin verimli çalışması için iki kısıt vardır:
 
-- AxCACHE/AxPROT sinyalleri "cacheable + bufferable" işaretlenmelidir
-  (Xilinx tipik olarak `0b1111` önerir).
-- Transfer büyüklüğü tercihen tam bir L1 cacheline (64 byte) olmalıdır; küçük
-  transferler SCU'da kuyruk oluşturur ve performansı düşürür.
+- AxCACHE sinyali write-back, write-allocate okunabilir/yazılabilir
+  (`0b1111`) olarak işaretlenmeli; AxPROT non-secure data (genelde `0b010`)
+  olmalıdır. Bu kombinasyon, PL master'ın işleminin SCU tarafından koherent
+  kabul edilmesini sağlar.
+- Transfer büyüklüğü tercihen tam bir L1/L2 cacheline (Zynq-7000'in Cortex-A9
+  ve PL310 yapılandırmasında **32 byte**) hizalı olmalıdır; küçük veya
+  hizasız transferler SCU'da read-modify-write doğurur ve performansı düşürür.
 
-ACP'nin pratik faydası, **ARM üzerinde son derece pahalı olan cache
-flush/invalidate çağrılarını tamamen ortadan kaldırmasıdır.** Linux'ta
-`Xil_DCacheFlushRange()` 4 KB için bile çift haneli mikrosaniye alırken, ACP
-yolu transferi cache'in içine sokar.
+ACP'nin pratik faydası, **ARM üzerinde pahalı olan cache flush/invalidate
+çağrılarını tamamen ortadan kaldırmasıdır.** Bare-metal BSP'de
+`Xil_DCacheFlushRange()` büyük tampon başına mikrosaniye mertebesi
+gecikme ekler — ACP yolu bu adımı tamamen atlar ve transferi cache'in içine
+sokar.
 
 **3. HP/GP portları — non-coherent PL→PS yolu.** HP (High Performance) ve GP
 (General Purpose) AXI portları DDR'a doğrudan erişir; SCU bypass olur. Burada
@@ -487,6 +474,28 @@ Sonuç pratiktir: Zynq-7000'de bir PL IP'sini tasarlarken **ACP'yi tercih
 edebiliyorsanız edin** — yazılım tarafı çok daha basitleşir. Edemiyorsanız
 cache maintenance + bariyer disiplininize kanıtlanabilir biçimde uyun;
 "unutmadık herhalde" iyi bir mühendislik argümanı değildir.
+
+---
+
+## Zynq-7000 Senaryoları İçin Karar Matrisi
+
+Üç koherans bölgesini ele aldıktan sonra, tipik senaryoları tek bir tabloda
+özetleyebiliriz:
+
+| Senaryo | Atomicity | Derleyici bariyeri | CPU bariyeri | Doğru araç |
+|---|---|---|---|---|
+| `volatile uint8_t` bayrağı, CPU0 ISR yazar, CPU0 main okur | `uint8_t` tek `STRB`, OK | OK | Aynı CPU: gereksiz | `_Atomic` yine daha güvenli (kod yarın CPU1'e taşınabilir) |
+| `pulse_count++`, CPU0 ISR + CPU0 main, aynı çekirdek | LDREX/STREX local monitor | Var | Gereksiz | `atomic_fetch_add_explicit(..., relaxed)` |
+| `pulse_count++`, CPU0 ISR + CPU1 main (SMP) | LDREX/STREX + SCU snoop şart | Şart | `DMB ISH` şart | `atomic_fetch_add_explicit(..., seq_cst)` |
+| Üretici-tüketici buffer, CPU0 → CPU1, OCM/DDR (cacheable, inner-shareable) | flag için OK | Şart | `DMB ISH` çifti | `release/acquire` çifti |
+| PS → PL DMA, GP/HP port (non-coherent) | Yazı OK | Şart | `DSB SY` + L1/L2 clean şart | `Xil_DCacheFlushRange()` + `__DSB()` + `volatile` register |
+| PS → PL DMA, ACP üzerinden (coherent) | Yazı OK | Şart | `DMB ISH` yeterli; cache clean **gereksiz** | `volatile` register; ACP master cacheline-hizalı burst |
+| PL → PS DMA, GP/HP port | DMA bitince L1/L2 invalidate şart | Şart | `DSB SY` invalidate öncesi | `Xil_DCacheInvalidateRange()` + bariyer |
+| Bellek-eşlenikli register (UART, GPIO, TTC) | Genelde tek talimat | Şart | Strongly-ordered sayfada otomatik | `volatile` (atomic değil, **donanım yan etkisi**) |
+
+Tek satıra indirgersek: **Kayıt (register) erişiminde `volatile`; paylaşılan
+veri erişiminde `_Atomic`; PL ile DMA paylaşımında cache maintenance + DSB
+veya ACP.** Bu üç kavram aynı isim değildir, aynı mekanizma hiç değildir.
 
 ---
 
@@ -526,19 +535,19 @@ cache maintenance + bariyer disiplininize kanıtlanabilir biçimde uyun;
 ```mermaid
 flowchart TD
     A[Paylaşılan veriye erişiyorum] --> B{Hedef nedir?}
-    B -- "PS register PL register UART/GPIO/TTC" --> C[volatile pointer kullan,<br/>strongly-ordered sayfa<br/>__DSB gerekirse]
-    B -- "PS RAM PS RAM iki CPU paylaşıyor" --> D{Tek okuma/yazma mı?}
-    B -- "PL DMA tampon" --> M{ACP kullanılıyor mu?}
-    D -- Evet --> E{Doğal hizalı native genişlik mi?}
-    E -- Evet --> F[_Atomic + relaxed<br/>SCU snoop devrede<br/>sayfa: Inner Shareable]
-    E -- Hayır --> G[_Atomic + uygun memory_order]
-    D -- Hayır RMW --> H[atomic_fetch_* kullan<br/>seq_cst varsayılan,<br/>kasıtlıysa relaxed]
+    B -- "PS/PL register (UART, GPIO, TTC)" --> C[volatile pointer<br/>strongly-ordered sayfa<br/>gerekirse __DSB]
+    B -- "PS RAM, iki CPU paylaşıyor" --> D{Tek okuma/yazma mı?}
+    B -- "PL DMA tampon" --> M{ACP yolu mu?}
+    D -- "Evet" --> E{Doğal hizalı, native genişlik mi?}
+    E -- "Evet" --> F[_Atomic + relaxed<br/>SCU snoop devrede<br/>sayfa Inner Shareable]
+    E -- "Hayır" --> G[_Atomic + uygun memory_order]
+    D -- "Hayır, RMW" --> H[atomic_fetch_* kullan]
     H --> I{Sıralama gerekiyor mu?}
-    I -- Sadece sayaç --> J[relaxed]
-    I -- Üretici-tüketici --> K[release/acquire çifti<br/>DMB ISH otomatik]
-    I -- Tam sıralama --> L[seq_cst — pahalı,<br/>gerçekten gerekli mi?]
-    M -- Evet --> N[ACP master<br/>cache flush GEREKMEZ<br/>64-byte burst tercih edin]
-    M -- Hayır HP/GP --> O[CPU→PL: Xil_DCacheFlushRange + DSB<br/>PL→CPU: Xil_DCacheInvalidateRange]
+    I -- "Sadece sayaç" --> J[relaxed]
+    I -- "Üretici-tüketici" --> K[release/acquire çifti<br/>DMB ISH otomatik]
+    I -- "Tam sıralama" --> L[seq_cst — pahalı,<br/>gerçekten gerekli mi?]
+    M -- "Evet, ACP" --> N[Cache flush GEREKMEZ<br/>cacheline hizalı burst<br/>32 byte]
+    M -- "Hayır, HP/GP" --> O[CPU→PL: Xil_DCacheFlushRange + DSB<br/>PL→CPU: Xil_DCacheInvalidateRange]
 ```
 
 Bu akış, "önce mimari, sonra araç" disiplinini dayatır. Zynq-7000'de doğru

--- a/_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md
+++ b/_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md
@@ -1,0 +1,511 @@
+---
+title: "`volatile` Yetmediğinde: C11 `_Atomic` ve Bellek Bariyerleri"
+subtitle: "When `volatile` Is Not Enough: C11 `_Atomic` and Memory Barriers"
+background: "/img/posts/3.webp"
+date: '2026-05-29 09:00:00'
+layout: post
+lang: tr
+mermaid: true
+---
+
+Gömülü dünyada en sık tekrarlanan yanılgılardan biri şudur: "değişkeni `volatile`
+yaparsam ISR ile main loop arasında güvenle paylaşabilirim". Bu cümle, yıllarca süren
+sahada-buluşan hata raporlarının, gece nöbetlerinin ve "ama lab'da çalışıyordu"
+ifadelerinin temel sebebidir. Yazının iddiası net: `volatile` ne C standardı ne de
+ARM mimarisi açısından bir eşzamanlılık (synchronization) ilkesi değildir; bunun için
+C11'in `<stdatomic.h>` başlığı, derleyici bariyerleri ve mimariye özgü bellek
+bariyerleri vardır.
+
+Bu yazıda önce `volatile`'ın gerçekte neyi garanti edip etmediğini standart
+diliyle çıkaracağız, sonra Cortex-M4 üzerinde aynı operasyonun `volatile` ve
+`_Atomic` versiyonlarının ürettiği assembly'yi yan yana koyup farkı göreceğiz.
+Ardından memory ordering meselesini (derleyici reordering + CPU reordering) ele
+alıp Cortex-M ailesinin tek çekirdek ve çok çekirdek senaryolarında ne gerekip ne
+gerekmediğine bakacağız. Son olarak Cortex-M0/M0+ ve M23'te `_Atomic`'in neden
+sessizce libatomic'e fallback ettiğini ve bunun gerçek maliyetini ortaya koyacağız.
+
+---
+
+## Bir Olay Yeri: Kaybolan Artırımlar
+
+Aşağıdaki kod parçası, internette bulunan onlarca "tutorial"in özüdür:
+
+```c
+volatile uint32_t pulse_count;
+
+void TIM2_IRQHandler(void) {
+    if (TIM2->SR & TIM_SR_UIF) {
+        TIM2->SR &= ~TIM_SR_UIF;
+        pulse_count++;
+    }
+}
+
+void main_loop(void) {
+    if (pulse_count >= 1000) {
+        pulse_count = 0;
+        trigger_event();
+    }
+}
+```
+
+Lab'da timer'ı 1 kHz'te koşturursunuz; her saniye `trigger_event()` çağrılır,
+LED yanar, herkes mutlu. Tek bir şey hariç: birkaç saatlik koşumdan sonra
+`trigger_event()` çağrılma oranı saniyede tam olarak bir değildir — bazen 1.001,
+bazen 0.998. Birkaç gün sonra müşteri sahadan "sayım kayıyor" bildirir.
+
+Sebep, Cortex-M4'ün `pulse_count++` için ürettiği makine kodudur:
+
+```text
+ldr  r3, [r2]      ; r3 <- pulse_count
+adds r3, r3, #1    ; r3 = r3 + 1
+str  r3, [r2]      ; pulse_count <- r3
+```
+
+Bu üç talimatın **arasına** bir kesme girerse — örneğin `LDR` ile `STR` arasına —
+main loop'un sıfırlama yazısı veya başka bir ISR'ın artırması kaybolur. `volatile`
+derleyiciye "bu değişkeni cache'leme, her erişimi bellekten yap" der; **ama tek
+talimatla yap** demez. Çünkü demez ki: C dili `volatile` için zaten böyle bir şey
+söylemez.
+
+---
+
+## `volatile`'ın C Standardındaki Anlamı
+
+ISO/IEC 9899:2011 §6.7.3p7'de `volatile` şöyle tanımlanır (öz Türkçeyle): *"Bir
+`volatile` nitelikli nesneye yapılan her erişim, gerçekleştirme tarafından
+soyut makinenin (abstract machine) kuralları uyarınca tam olarak ortaya çıkmalıdır.
+Aksini gerektiren herhangi bir nedenin yokluğunda, `volatile` nesneye yapılan
+erişimler kaynak kodda göründükleri sıralamada gerçekleşmelidir."*
+
+Bu cümle iki şey söyler:
+
+1. Her okuma ve yazma **gerçekten olur** — derleyici onu yutamaz, başka
+   okumayla birleştiremez.
+2. Aynı `volatile` nesneye yapılan erişimler, kaynak kodda göründükleri sıralamada
+   görünür.
+
+Bu cümlenin söylemediği üç şey vardır ve hata kaynağı tam olarak burasıdır:
+
+1. **Atomicity yok.** Tek bir okuma veya yazmanın tek talimatta yapılacağına
+   dair garanti yoktur. `volatile uint64_t` Cortex-M üzerinde iki `LDR` ile
+   okunur; aralarına kesme girer.
+2. **Diğer nesnelere göre sıralama yok.** `volatile a` ile yapılan okumanın,
+   sıradan bir `b` değişkenine yapılan yazmadan önce bitmesi garanti değildir —
+   derleyici onları rahatlıkla değiştirir.
+3. **Çekirdekler arası görünürlük yok.** Multi-core sistemde bir çekirdeğin
+   yaptığı `volatile` yazı, diğerinin önbelleğine kendiliğinden ulaşmaz; bunun
+   için cache maintenance + bellek bariyeri gerekir.
+
+Linus Torvalds ve Jonathan Corbet Linux çekirdeği belgesi
+[volatile-considered-harmful.rst](https://www.kernel.org/doc/html/next/process/volatile-considered-harmful.html)
+içinde durumu sert özetler (özet çeviri): "Çekirdek kodunda `volatile`'a
+neredeyse hiç ihtiyaç yoktur; ortaya çıkıyorsa, neredeyse her zaman daha derin
+bir eşzamanlılık hatasının semptomudur." SEI CERT C kuralı
+[CON02-C](https://wiki.sei.cmu.edu/confluence/x/utYxBQ) ise tek cümleyle özetler:
+"Do not use volatile as a synchronization primitive."
+
+`volatile`'ın **gerçek** ve haklı kullanım alanları şunlardır:
+
+- Bellek-eşlenikli (memory-mapped) donanım registerları (`*((volatile uint32_t*)
+  0x40020000) = 0xA5;`).
+- `setjmp`/`longjmp` arasında değeri korunan otomatik değişkenler.
+- POSIX `sigatomic_t` veya `_Atomic`'siz ortamlarda, signal handler ile
+  iletilen **tek bayraklar** (yalnızca yazılır/okunur, RMW yapılmaz).
+
+Bu liste kasıtlı olarak kısadır. ISR'a sayaç paylaşmak, mesaj kuyruğunu yönetmek,
+durum makinesini iki çekirdek arasında senkronlamak — hiçbiri bu listede yoktur.
+
+---
+
+## Cortex-M4 Üzerinde Assembly Karşılaştırması
+
+`arm-none-eabi-gcc 13.2` ile `-O2 -mcpu=cortex-m4 -mthumb` bayrakları altında iki
+fonksiyonu derleyip üretilen kodu karşılaştıralım.
+
+### Tek artırım — `volatile` versiyon
+
+```c
+#include <stdint.h>
+
+volatile uint32_t v_counter;
+
+void v_inc(void) {
+    v_counter++;
+}
+```
+
+Üretilen kod:
+
+```text
+v_inc:
+    ldr     r3, .L2          ; r3 = &v_counter
+    ldr     r2, [r3]         ; r2 = v_counter
+    adds    r2, r2, #1
+    str     r2, [r3]         ; v_counter = r2
+    bx      lr
+.L2:
+    .word   v_counter
+```
+
+Üç bellek/aritmetik talimat. Kesme `LDR` ile `STR` arasına düşerse artırım
+kaybolur. Bu kodun atomik olduğuna dair hiçbir varsayım yapılamaz.
+
+### Aynı artırım — C11 `_Atomic` versiyon
+
+```c
+#include <stdint.h>
+#include <stdatomic.h>
+
+atomic_uint a_counter;
+
+void a_inc(void) {
+    atomic_fetch_add_explicit(&a_counter, 1, memory_order_relaxed);
+}
+```
+
+Üretilen kod (aynı bayraklarla):
+
+```text
+a_inc:
+    ldr     r3, .L5
+1:  ldrex   r2, [r3]         ; exclusive load, monitor "watch" set
+    adds    r2, r2, #1
+    strex   r1, r2, [r3]     ; exclusive store; r1 = 0 başarı
+    cmp     r1, #0
+    bne     1b               ; başarısızsa baştan dene
+    bx      lr
+.L5:
+    .word   a_counter
+```
+
+Fark görünür: LDREX/STREX çifti, ARMv7-M'in **exclusive monitor**'ünü kullanarak
+"oku — değiştir — yaz" döngüsünü güvenli hale getirir. Eğer LDREX ile STREX
+arasında başka bir context (ISR, başka bir CPU) aynı adrese yazarsa STREX
+başarısız olur (`r1 = 1`), kod döngünün başına döner ve yeniden dener. Bu
+desen, ARM mimarisinde **LL/SC** (load-linked / store-conditional) ailesinden
+gelir ve karşılıklı dışlama (mutual exclusion) için temeldir.
+
+Cortex-M4 tek çekirdekli bir mimari olduğu için "diğer çekirdekten yazma"
+ihtimali yoktur; LDREX/STREX burada **yalnızca local monitor**'ü kullanır ve
+asıl koruma kesmeye karşıdır. ISR `STREX`'in çalışmasından önce devreye girerse
+local monitor temizlenir, STREX başarısız olur, döngü tekrar dener — sayım
+kaybolmaz.
+
+`-O2 -mcpu=cortex-m0` ile aynı kodu derlerseniz manzara değişir: ARMv6-M'de
+LDREX/STREX **yok**. GCC `a_inc` için `__atomic_fetch_add_4` çağrısı üretir;
+bu sembol libatomic'tedir. Libatomic'in M0+ implementasyonu tipik olarak
+`__sync` kütüphanesi arkasında PRIMASK'i set/clear ederek kesmeleri kapatır.
+Yani aynı kaynak kodu, hedefe göre 8 talimatlık inline döngüye veya bir
+fonksiyon çağrısı + IRQ disable/enable köprüsüne dönüşür. Bunu bilmeden kullanan
+ekipler, yumuşak gerçek-zaman sistemlerinde beklenmedik **kesme gecikmesi**
+(interrupt latency) ile karşılaşır.
+
+---
+
+## Memory Ordering: İki Katmanlı Yeniden Sıralama
+
+`volatile`'ın yapamadığı ikinci kategori, **sıralama** garantisidir. Modern
+sistemlerde sıralamayı bozan iki bağımsız mekanizma vardır:
+
+```text
+Kaynak kod sıralaması
+        |
+        v   (1) Derleyici yeniden sıralaması
+        |
+Makine kodu sıralaması
+        |
+        v   (2) CPU yeniden sıralaması
+        |
+Belleğe görünen sıralama
+```
+
+### (1) Derleyici reordering
+
+Modern bir C derleyicisi, `as-if` kuralının izin verdiği her yerde komutları
+yeniden sıralar:
+
+```c
+flag = 0;
+buffer[0] = 0xDE;
+buffer[1] = 0xAD;
+flag = 1;
+```
+
+Derleyici, `flag = 0` ve `flag = 1` yazılarını birleştirip yalnızca sonuncusunu
+bırakabilir veya `flag = 1`'i buffer yazılarından önceye taşıyabilir (eğer
+`flag` ile `buffer` arasında veri bağımlılığı görmüyorsa). `flag`'i `volatile`
+yapmak bu işin yarısını çözer (yazıyı yutamaz), ama `flag = 1`'in `buffer`
+yazılarından önce gelmemesini **garanti etmez** — `buffer` `volatile` değilse
+derleyicinin önünde engel yoktur.
+
+İki klasik koruma vardır:
+
+- `asm volatile ("" ::: "memory")` — GCC'ye özgü tam derleyici bariyeri.
+  Hiçbir talimat üretmez, ama compiler'a "memory bu noktada değişti, hiçbir
+  varsayımı taşıma" der.
+- C11 atomik operasyonu uygun `memory_order` ile çağırmak. `atomic_store_explicit
+  (&flag, 1, memory_order_release)` hem derleyiciye hem CPU'ya "önceki tüm
+  yazıların görünür olduğundan emin ol" der.
+
+### (2) CPU reordering
+
+CPU tarafı, mimariye göre çok farklıdır. ARM ailesi **weakly-ordered**'dir;
+yani CPU, veri bağımlılığı olmayan okuma ve yazmaları kendi başına yeniden
+sıralayabilir. Yayınlanan koşum sırası, yazıldığı sırayla aynı olmak zorunda
+değildir.
+
+ARM bunu üç bariyer talimatıyla kontrol eder:
+
+| Talimat | Anlamı | Tipik kullanım |
+|---|---|---|
+| `DMB` | Data Memory Barrier — bu noktadan önceki tüm bellek erişimleri sonrakilerden önce görünür olur | Spinlock al/bırak; çekirdekler arası paylaşılan veri |
+| `DSB` | Data Synchronization Barrier — DMB + öndeki tüm bellek erişimleri tamamlanmadan sonraki talimat başlamaz | Cache maintenance sonrası; MPU/MMU konfigürasyonu |
+| `ISB` | Instruction Synchronization Barrier — pipeline'ı temizler; sonraki talimatlar yeniden fetch edilir | Vector tablosu/SCB yapılandırma sonrası |
+
+Burada kritik bir nokta var: **Cortex-M ailesi tek çekirdeklidir** (klasik
+konfigürasyonda). Tek çekirdek üzerinde aynı çekirdeğin yaptığı yazıları kendi
+sonraki okumaları **her zaman** sıralı görür — bu mimari garantidir. O zaman
+DMB neden gerekir?
+
+İki sebep:
+
+1. **DMA ile paylaşılan tampon.** CPU'nun yazısı henüz write buffer'da olabilir;
+   DMA controller'a "başla" yazmadan önce DSB ile yazıların gerçekten belleğe
+   ulaşması garantilenir.
+2. **Çok çekirdekli sistem.** Heterojen Cortex-M+M (STM32H7'nin M7+M4
+   konfigürasyonu, NXP i.MX RT1170 M7+M4 gibi) ve tüm Cortex-A SMP
+   sistemlerinde DMB şarttır; aksi halde diğer çekirdek yazıları yanlış sırayla
+   görür.
+
+Yani tek çekirdek Cortex-M üzerinde **thread + ISR** senaryosunda DMB
+**gereksizdir**. LDREX/STREX local monitor'ı yeterlidir. Bu, çok sayıda örnek
+kodun gereksiz `__DMB()` çağrısı içermesinin temel sebebidir — büyük ölçüde
+"copy-paste'tan multi-core kod" mirasıdır.
+
+---
+
+## C11 `<stdatomic.h>`: Doğru Aracın Anatomisi
+
+C11 atomicleri üç katman sunar:
+
+1. **Tür belirteci/niteleyici:** `_Atomic int`, `_Atomic(int)`, `atomic_int`
+   (typedef). Aynı şey için üç yazım vardır.
+2. **Generic fonksiyonlar:** `atomic_load`, `atomic_store`, `atomic_fetch_add`,
+   `atomic_compare_exchange_weak`/`_strong`, `atomic_exchange`. Bunlar default
+   olarak `memory_order_seq_cst` kullanır.
+3. **`_explicit` varyantlar:** Aynı fonksiyonların `_explicit` sonekli halleri,
+   `memory_order` parametresi alır.
+
+Memory order seçenekleri ve ne işe yaradıkları:
+
+| Order | Garanti | Tipik kullanım |
+|---|---|---|
+| `relaxed` | Sadece atomicity; sıralama yok | İstatistik sayaçları, telemetri |
+| `consume` | Bağımlılık zinciri korunur | Nadir; çoğu derleyici `acquire`'a eşitler |
+| `acquire` | Bu okumadan sonra gelen erişimler önce sıçramaz | Lock alma, üretici-tüketici tüketici tarafı |
+| `release` | Bu yazıdan önceki erişimler sonra sıçramaz | Lock bırakma, üretici-tüketici üretici tarafı |
+| `acq_rel` | İkisi birden | `fetch_add`/`exchange` ile lock-free yapı |
+| `seq_cst` | Total sıralama; tüm thread'ler aynı sırayı görür | Varsayılan; en pahalı |
+
+Pratik bir örnek — üretici-tüketici flag'i:
+
+```c
+#include <stdatomic.h>
+
+static uint8_t  buffer[64];
+static atomic_int ready = 0;       /* 0: boş, 1: dolu */
+
+void producer(void) {
+    fill_buffer(buffer);
+    atomic_store_explicit(&ready, 1, memory_order_release);
+}
+
+bool consumer(void) {
+    if (atomic_load_explicit(&ready, memory_order_acquire) == 1) {
+        process_buffer(buffer);
+        atomic_store_explicit(&ready, 0, memory_order_release);
+        return true;
+    }
+    return false;
+}
+```
+
+Burada `release` ve `acquire` çifti hem derleyiciye hem CPU'ya şunu söyler:
+"Üretici'nin `fill_buffer` içindeki tüm yazıları, `ready = 1`'i gören bir
+tüketici tarafından **mutlaka** görülmüş olmalıdır." `volatile` ile bu garanti
+elde edilemez; çünkü `volatile` ne derleyici reordering'ini diğer değişkenlere
+karşı engeller, ne de CPU bariyeri üretir.
+
+Cortex-M4'te `release` store, derleyiciye bir `DMB` talimatı ürettirir
+(multi-core veya DMA paylaşımı varsa anlamlıdır; tek-core thread+ISR
+senaryosunda bile derleyici bariyeri kazancı vardır). Cortex-A SMP'de ise gerçek bir CPU bariyeri olur.
+
+---
+
+## Tek Çekirdek vs Çok Çekirdek: Karar Matrisi
+
+| Senaryo | Atomicity | Derleyici bariyeri | CPU bariyeri | Doğru araç |
+|---|---|---|---|---|
+| Tek `volatile uint8_t` bayrağı, ISR yazar, main okur, Cortex-M | `uint8_t` zaten tek talimat, OK | Aynı değişken için OK | Tek-core: gereksiz | `volatile` *yetebilir* — ama `_Atomic` daha güvenli |
+| `pulse_count++`, ISR + main, Cortex-M4 | LDREX/STREX şart | Var | Gereksiz | `atomic_fetch_add_explicit(..., relaxed)` |
+| Üretici-tüketici buffer, ISR + main, Cortex-M4 | flag için OK | Şart | Gereksiz (single-core) | `atomic_store/load_explicit(..., release/acquire)` |
+| DMA tampon, CPU yazar, DMA okur | Yazı OK | Şart | `DSB` şart (DMA başlatma öncesi) | `__DSB()` + `volatile` register |
+| Dual M7 / Cortex-A SMP, paylaşılan kuyruk | Şart | Şart | `DMB` şart | `_Atomic` + `release/acquire` |
+| Bellek-eşlenikli register (UART, GPIO) | Genelde tek talimat | Şart | Mimariye göre | `volatile` (atomic değil, **donanım yan etkisi**) |
+
+Tek satıra indirgersek: **Kayıt (register) erişiminde `volatile`; paylaşılan
+veri erişiminde `_Atomic`.** Bu iki kavram aynı isim değildir, aynı mekanizma
+hiç değildir.
+
+---
+
+## Cortex-M0/M0+ ve M23: `_Atomic`'in Sessiz Bedeli
+
+ARMv6-M (M0, M0+, M1) ve ARMv8-M Baseline (M23) ailesi exclusive monitor
+içermez. Bu hedeflerde GCC `<stdatomic.h>`'i koruyabilmek için libatomic
+kullanır. Tipik bir `atomic_fetch_add` çağrısı şuna benzer:
+
+```text
+a_inc:
+    push    {r4, lr}
+    movs    r2, #5            ; memory_order_seq_cst (5)
+    movs    r1, #1            ; ekleme miktarı
+    ldr     r0, .L3           ; &a_counter
+    bl      __atomic_fetch_add_4
+    pop     {r4, pc}
+.L3:
+    .word   a_counter
+```
+
+Fonksiyon çağrısının arkasında, libatomic'in M0+ implementasyonu PRIMASK'i
+kaydeder, kesmeleri kapatır, RMW yapar, PRIMASK'i geri yükler. Bu yaklaşımın
+iki bedeli vardır:
+
+1. **Kesme gecikmesi.** Critical section, dış fonksiyon çağrısı + iki PRIMASK
+   manipülasyonu boyunca aktiftir. Yumuşak gerçek-zaman sistemlerde her atomik
+   operasyon ~10-20 cycle pin daha yüksek interrupt jitter doğurur.
+2. **Link zamanı bağımlılığı.** Bare-metal projelerde libatomic her zaman link
+   edilemez; `-latomic` ihtiyacı vardır ve newlib-nano ile çakışmalar olabilir.
+
+Bu nedenle gömülü ekipler ARMv6-M hedeflerinde sık sık alternatif bir yol
+seçer: kritik bölge etrafında elle `__disable_irq()`/`__enable_irq()` veya
+ARM'ın "atomic register access" pattern'i. Bu seçim, "küçük çip, küçük araç
+seti" pragmatizmidir; ama gerçek `volatile` ile aynı şey değildir — sadece
+implementasyon detayıdır.
+
+---
+
+## Sık Yapılan Beş Hata
+
+1. **`volatile` bayrak ile spinlock kurmak.** `while (locked) {}` ile beklemek
+   atomik gibi görünse de iki çekirdek arasında yarış vardır. Doğrusu:
+   `atomic_flag_test_and_set_explicit(&lock, memory_order_acquire)`.
+2. **`_Atomic struct` ile büyük yapı kullanmak.** C11 izin verir, ama
+   derleyici `sizeof` belirli eşiklerin üstünde tüm yapıyı libatomic'in lock
+   tablosuna yönlendirir. Sonuç: her erişim hash-locked. Büyük yapıları açıkça
+   bir mutex ile koruyun.
+3. **64-bit `_Atomic` ARMv7-M üzerinde.** LDREXD/STREXD var ama derleyici hep
+   üretmez; -O ayarlarına göre libatomic'e düşülebilir. `__atomic_always_lock_free
+   (8, 0)` ile derleme zamanında kontrol edin.
+4. **`memory_order_consume` kullanmak.** Standart tanımı pratik derleyicilerin
+   doğru uygulayamadığı kadar karmaşıktır; tüm yaygın derleyiciler bunu
+   `acquire`'a yükseltir. C++ komitesi 2017'den beri yeniden tanımlamayı
+   tartışıyor. Kullanmayın.
+5. **Cortex-M tek-core'da gereksiz `__DMB()` serpiştirmek.** Performans
+   maliyeti küçük ama sıfır değil, ve daha kötüsü kodun çok-core'a taşındığı
+   yanılgısını yaratır. Asıl koruma `_Atomic` + uygun memory order'dır;
+   bariyer talimatı bunun **yan ürünüdür**.
+
+---
+
+## Bir Karar Akışı
+
+```mermaid
+flowchart TD
+    A[Paylaşılan veriye erişiyorum] --> B{Donanım registerı mı?}
+    B -- Evet --> C[volatile pointer kullan,<br/>gerekirse __DSB/__DMB]
+    B -- Hayır --> D{Tek bir okuma veya yazma mı?}
+    D -- Evet --> E{Doğal hizalı ve native genişlik mi?}
+    E -- Evet --> F[_Atomic + relaxed yeterli<br/>Donanım tek talimat üretir]
+    E -- Hayır --> G[_Atomic kullan, libatomic'e düşebilir]
+    D -- Hayır, RMW --> H[atomic_fetch_* kullan]
+    H --> I{Sıralama gerekiyor mu?}
+    I -- Hayır, sadece sayaç --> J[relaxed]
+    I -- Üretici-tüketici --> K[release/acquire çifti]
+    I -- Tam sıralama --> L[seq_cst — pahalı, gerçekten gerekli mi?]
+```
+
+Bu akış, "önce mimari, sonra araç" disiplinini dayatır. `volatile`'a karar
+verirken sorduğumuz tek soru "bu adres bir cihaz registerı mı?" olmalıdır.
+Bir `_Atomic`'e karar verirken sorduğumuz soru "bu veriyi başka bir context
+de görüyor mu, ve görmesi gereken sırada görmek zorunda mı?" olmalıdır.
+
+---
+
+## Bir Sahte Çözüm: "Tek baytlık değişken atomiktir"
+
+İnternette tekrarlanan bir başka mit: "`uint8_t` veya `bool` zaten tek talimatta
+yazılır, `volatile` yeterli". Bu kısmen doğrudur — tek baytlık doğal hizalı
+yazı ARM'da gerçekten tek `STRB` ile yapılır, dolayısıyla atomicity sorunu
+**yoktur**. Ama:
+
+- Yazma atomiktir, **okuma + yazma atomik değildir.** `flag = !flag;` üç
+  talimattır.
+- Yazma diğer değişkenlerle sıralama garanti **etmez.** Üretici-tüketici
+  senaryosunda buffer yazıları bayraktan sonra görünebilir.
+- Multi-core sistemde diğer çekirdek bu yazıyı kendi cache'i nedeniyle eski
+  görebilir.
+
+Yani "tek baytlık `volatile` yeterli" cümlesi, "kesinlikle bir bayrak okuyup
+yazıyorum, başka değişkene bağlamıyorum, tek çekirdekteyim" kısıtının altında
+doğrudur. Bu kısıtın hayatınızdaki ömrü kısadır; kodun yarın multi-core'a
+taşınma ihtimali yüksektir. Doğru alışkanlık baştan `_Atomic` yazmaktır;
+ek maliyeti tek-core hedefte çoğu durumda sıfırdır.
+
+---
+
+## Sonuç
+
+`volatile` C dilinin önemli ama dar bir aracıdır: derleyicinin "bu değişken
+bana göre değişmez" varsayımını kıran bir niteleyici. Donanım registerı
+erişiminde, signal handler'la basit bayrak alışverişinde, `setjmp`/`longjmp`
+arasında değer korumada yeri vardır. Hiçbirinin adı "eşzamanlılık" değildir.
+
+Eşzamanlılık kelimesi C dilinde C11 ile birlikte gelmiştir: `_Atomic` türleri,
+`<stdatomic.h>` fonksiyonları, ve `memory_order` enum'u. Bunlar atomicity,
+sıralama ve çekirdekler arası görünürlüğü tek bir tutarlı modelde birleştirir.
+ARM mimarisi üzerinde bu modelin altyapısı LDREX/STREX, DMB/DSB/ISB ve
+ARMv8'in load-acquire/store-release talimatlarıyla sağlanır.
+
+Yazılım emniyet kritik olduğunda ve özellikle DO-178C DAL-A gibi seviyelerde
+bu ayrımın belgelenmesi de önemlidir. Statik analiz araçları (Polyspace,
+Astrée, Coverity) `volatile` ile korunmaya çalışılan paylaşımları "data race"
+olarak işaretler ve haklıdır. Standart sürecin "MC/DC kapsama" gibi sıkı kuralı
+varsa, eşzamanlılık modelinin doğru olduğunu kanıtlamak da aynı disiplinin
+parçasıdır.
+
+Bir sonraki ISR sayacınızı `volatile uint32_t` ile yazmadan önce iki kere
+düşünün. `atomic_uint` ek bir satır değildir; arkasında yarım yüzyıllık
+mimari kararların ve bir dil standardının düşünülmüş yanıtı vardır.
+
+---
+
+## Kaynaklar
+
+- ISO/IEC 9899:2011, "Programming languages — C" — §6.7.3 ("volatile"), §7.17
+  ("Atomics"). (Standart taslağı: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf>)
+- [The Linux Kernel Documentation — Why the "volatile" type class should not be
+  used](https://www.kernel.org/doc/html/next/process/volatile-considered-harmful.html)
+- [SEI CERT C Coding Standard — CON02-C. Do not use volatile as a
+  synchronization primitive](https://wiki.sei.cmu.edu/confluence/x/utYxBQ)
+- [cppreference — `<stdatomic.h>` (C11)](https://en.cppreference.com/w/c/header/stdatomic.html)
+- [LWN — The trouble with volatile (Jonathan Corbet, 2007)](https://lwn.net/Articles/233479/)
+- [Embedded.com — Jack Ganssle, "C keywords: Don't flame out over
+  volatile"](https://www.embedded.com/c-keywords-dont-flame-out-over-volatile/)
+- ARM Architecture Reference Manual ARMv7-M, DDI 0403E.e — Bölüm A3.4
+  ("Synchronization and semaphores") ve A4.5 ("Memory barriers").
+- ARM Architecture Reference Manual ARMv6-M, DDI 0419E.
+- Hans-J. Boehm, "Threads Cannot Be Implemented as a Library", PLDI 2005 — C
+  bellek modelinin neden dil seviyesinde gerekli olduğunu açıklayan kurucu makale.
+- [ARM Community — LDREX/STREX on M3, M4, M7](https://community.arm.com/support-forums/f/architectures-and-processors-forum/10361/ldrex-strex-on-the-m3-m4-m7)
+- [SoC.org — How to implement atomic operations on multi-core Cortex-M0/M0+?](https://s-o-c.org/how-to-implement-atomic-operations-on-multi-core-cortex-m0-m0/)

--- a/agent/research/volatile-yetmediginde-c11-atomic.md
+++ b/agent/research/volatile-yetmediginde-c11-atomic.md
@@ -1,0 +1,80 @@
+# Araştırma: `volatile` Yetmediğinde — C11 `_Atomic` ve Bellek Bariyerleri
+
+## Doğrulanmış olgular
+
+- **C11** (ISO/IEC 9899:2011) `<stdatomic.h>` başlığını ve `_Atomic` tür belirteci
+  (type specifier) / tür niteleyicisini (type qualifier) ekledi. C18 (ISO/IEC
+  9899:2018) ve C23 (ISO/IEC 9899:2024) bunu sürdürdü.
+- C11'in tanımladığı memory order değerleri: `memory_order_relaxed`,
+  `memory_order_consume`, `memory_order_acquire`, `memory_order_release`,
+  `memory_order_acq_rel`, `memory_order_seq_cst`. Varsayılan (non-`_explicit`)
+  fonksiyonlar `seq_cst` kullanır.
+- `volatile`'ın C standardındaki amacı: derleyicinin değişkene yapılan erişimleri
+  optimize etmesini engellemek (yani "abstract machine"in görmediği yan etkiler için
+  görünür hale getirmek). Atomicity, ordering veya inter-thread visibility garantisi
+  **vermez**.
+- ARM mimari ailesi:
+  - **ARMv6-M** (Cortex-M0, M0+, M1): LDREX/STREX **yok**. Atomicity için
+    `PRIMASK` ile `CPSID i` / `CPSIE i` (kesme maskeleme).
+  - **ARMv7-M** (Cortex-M3, M4, M7): LDREX/STREX/CLREX, DMB/DSB/ISB var.
+  - **ARMv8-M Baseline** (Cortex-M23): LDREX/STREX **yok**.
+  - **ARMv8-M Mainline** (Cortex-M33, M55, M85): LDREX/STREX var; ayrıca load-acquire
+    / store-release seçenekleri.
+  - **ARMv7-A / ARMv8-A** (Cortex-A): zayıf bellek modeli; çok çekirdek; LDAR/STLR
+    (acquire/release) ARMv8'de.
+- Single-core Cortex-M üzerinde aynı çekirdek üzerinde çalışan thread + ISR için
+  cache coherency veya inter-CPU ordering sorunu yok; tek dert RMW atomicity ve
+  derleyici reordering. DMB gerekmez (yalnızca core local).
+- Multi-core sistemlerde (dual M7, M4+M0+, Cortex-A SMP) DMB ve cache invalidation
+  zorunlu.
+- GCC `<stdatomic.h>` arm-none-eabi'de: ARMv7-M+ için inline LDREX/STREX üretir;
+  ARMv6-M için libatomic'e fallback ve oradan IRQ disable.
+
+## Linus Torvalds — `volatile` zararlıdır
+
+Kaynak: linux/Documentation/process/volatile-considered-harmful.rst.
+Özet: `volatile` optimizasyonu bastırır, eşzamanlılığı korumaz; doğru araç kilit veya
+atomik tiptir.
+
+## SEI CERT CON02-C
+
+"Do not use volatile as a synchronization primitive." Resmî CERT C kuralı.
+
+## Açık örnek failure modu
+
+```c
+volatile uint32_t counter;          // ISR ve main loop artırıyor
+counter++;                          // 3 talimat: LDR, ADD, STR
+                                    // Araya kesme girerse artış kaybolur
+```
+
+## Kullanılacak derinlik öğesi
+
+**Assembly inspection.** `arm-none-eabi-gcc -Os -mcpu=cortex-m4` ile aynı
+operasyonun `volatile uint32_t` ve `atomic_uint` versiyonları derlenir; üretilen kod
+karşılaştırılır. LDREX/STREX döngüsünün ortaya çıkışı somut olarak gösterilir.
+
+## Yapı
+
+1. Açılış: gerçek bir kaybolan-artırım hikâyesi (counter race).
+2. `volatile`'ın C standardı tanımı (yan etki/abstract machine).
+3. `volatile`'ın YAPMADIĞI üç şey.
+4. Cortex-M4 üzerinde assembly karşılaştırması.
+5. Memory ordering: derleyici + CPU reordering.
+6. C11 `<stdatomic.h>` çözümü ve memory order pratiği.
+7. Single-core (Cortex-M) vs multi-core farkı; DMB ne zaman?
+8. Cortex-M0/M23 ve `_Atomic` tuzağı (libatomic fallback).
+9. Pratik karar matrisi.
+10. Tuzaklar (RMW maliyeti, `_Atomic` struct, padding).
+11. Sonuç + Kaynaklar.
+
+## Kaynaklar listesi (gerçek)
+
+- Linux kernel: volatile-considered-harmful.rst
+- SEI CERT CON02-C
+- cppreference: <stdatomic.h>
+- Embedded.com: "C keywords: Don't flame out over volatile" — Jack Ganssle
+- ARM Architecture Reference Manual ARMv7-M (DDI 0403E)
+- ARM Architecture Reference Manual ARMv6-M (DDI 0419C)
+- ISO/IEC 9899:2011 §6.7.3 (volatile), §7.17 (stdatomic.h)
+- Hans-J. Boehm, "Threads cannot be implemented as a library" (PLDI 2005)

--- a/agent/topics.md
+++ b/agent/topics.md
@@ -22,11 +22,19 @@
 - [x] Ölçüm Belirsizliği (GUM Annex F + NCSLI RP-12) — 2026-05-06 — alan: metroloji
 - [x] Kalibrasyon Zincirinin Tepesi (Birincil Standartlar) — 2026-05-07 — alan: metroloji
 - [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14 — alan: gömülü/SoC
+- [x] Bandpass Sampling: 1 GHz Sinyali 50 MHz Clock ile Örneklemek — 2026-05-21 — alan: RF/DSP
+- [x] Sistem Mühendisliği Nedir? — 2026-05-26 — alan: sistem
 
 ## Açık PR'lar (insan inceleme bekleniyor)
 
 | PR # | Başlık | Dal | Açılış | Alan |
 |------|--------|-----|--------|------|
+| [#99](https://github.com/mavrikant/mavrikant.github.io/pull/99) | Dört Aşamalı Veri Analitiği — Mühendislikte Tanımlayıcıdan Kuralcıya | post/2026-05-30-dort-asamali-veri-analitigi-muhendislik | 2026-05-30 | analitik/mühendislik |
+| [#98](https://github.com/mavrikant/mavrikant.github.io/pull/98) | WCET Analizi — Statik, Ölçüm, Cache | post/2026-05-28-wcet-analizi-statik-olcum-cache | 2026-05-28 | gerçek zamanlı |
+| [#96](https://github.com/mavrikant/mavrikant.github.io/pull/96) | Fault Tree Analizi ve Minimal Cut Set | post/2026-05-27-fault-tree-analizi-minimal-cut-set | 2026-05-27 | güvenilirlik |
+| [#90](https://github.com/mavrikant/mavrikant.github.io/pull/90) | Linker Script Anatomisi — ARM Bare-Metal `.ld` | post/2026-05-26-linker-script-anatomisi-arm-bare-metal | 2026-05-26 | gömülü |
+| [#89](https://github.com/mavrikant/mavrikant.github.io/pull/89) | Watchdog Timer Tasarım Desenleri | post/2026-05-24-watchdog-tasarim-desenleri | 2026-05-24 | güvenilirlik |
+| [#88](https://github.com/mavrikant/mavrikant.github.io/pull/88) | WCET Analizi: Statik mi, Ölçüm mü, Hibrit mi? | post/2026-05-23-wcet-analizi-statik-olcum-hibrit | 2026-05-23 | gerçek zamanlı (⚠ #98 ile çakışıyor) |
 | [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | post/2026-05-20-crc-polinom-secimi-ve-hamming-mesafesi | 2026-05-20 | yazılım zanaatı/hata tespiti |
 | [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR Geometrisi | post/2026-05-19-vor-faz-karsilastirma | 2026-05-19 | navigasyon |
 | [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A | post/2026-05-18-mcdc-kapsama-do-178c-dal-a | 2026-05-17 | sertifikasyon |
@@ -35,18 +43,21 @@
 | [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | blog/misra-c-statik-analiz | 2026-03-28 | standart/C (#69 ile çakışma riski!) |
 | [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ (eski yazı genişletme) | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
 
-> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. İnceleyen kişinin dikkatine.
+> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. Ayrıca PR #88 ve #98 her ikisi de WCET analizi konusunda — biri tercih edilip diğeri kapatılmalı.
 
 ## Seçildi / Devam Eden
 
-- **Bandpass Sampling: 1 GHz Sinyali 50 MHz Saatle Örneklemek** —
-  dal: `post/2026-05-21-bandpass-sampling`,
-  dosya: `_posts/2026-05-21-bandpass-sampling.md`,
-  durum: PR açılacak (bu çalıştırma) — alan: RF/DSP.
+- **`volatile` Yetmediğinde: C11 `_Atomic` ve Bellek Bariyerleri** —
+  dal: `post/2026-05-29-volatile-yetmediginde-c11-atomic`,
+  dosya: `_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md`,
+  durum: PR açılacak (bu çalıştırma) — alan: C/eşzamanlılık + ARM.
 
 ## Reddedildi (bu çalıştırma)
 
-- _(bu çalıştırmada konu reddedilmedi; bandpass sampling havuzdan seçildi.)_
+- WCET, Watchdog, Linker script, Fault Tree → zaten açık PR'da (#88/#98, #89, #90, #96)
+- CRC polinom, VOR, MC/DC, bellek güvenliği, UB, MISRA-statik, FTZ/DAZ → zaten açık PR'da
+- IQ örnekleme → alan rotasyonu (son 3 yazıdan biri RF/DSP idi — bandpass sampling)
+- Cortex-A boot, GIC, Cache MESI → alan rotasyonu (Renode yazısı gömülü/SoC idi); ayrıca seçilen `_Atomic` konusu mimari bariyerlerde bunlarla zaten kısmen örtüşüyor
 
 ## Fikir Havuzu (aday konular — gelecek çalıştırma için)
 
@@ -73,8 +84,8 @@ geçici olarak karşılıyor. Faz 2'de tekrar değerlendirilmesi gerekir.
       alan: gömülü — kendi linker script'i yazma rehberi
 - [ ] **Watchdog tasarım desenleri: tek vs çoklu görev watchdog, deadman switch,
       windowed watchdog** — alan: güvenilirlik — gerçek tasarım kararları
-- [ ] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
-      alan: C/eşzamanlılık — derleyici çıktı analizi
+- [x] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
+      → 2026-05-29 yazısı seçildi
 - [ ] **VOR'un çalışma prensibi: 30 Hz referans + değişken faz nasıl yön verir?** —
       alan: navigasyon — faz farkı matematiği + sinyal şeması
 - [ ] **ILS anatomisi: localizer 90/150 Hz DDM ve glide slope** —


### PR DESCRIPTION
## Konu

`volatile` Yetmediğinde: Zynq-7000 Üzerinde C11 `_Atomic`, SCU ve Bellek Bariyerleri — gömülü C dünyasında en sık tekrarlanan yanılgılardan biri olan "`volatile` ISR ile main loop arasında veri paylaşımı için yeterlidir" iddiasını Zynq-7000 (dual Cortex-A9 SMP, SCU, ACP, PL DMA) bağlamında çürüten teknik yazı.

## Neden bu konu seçildi?

- **Türkçe boşluk:** Konu C dünyasında çok tartışılmıştır (Linus Torvalds, SEI CERT, LWN, Embedded.com), ama Zynq-7000'in PS-PL ve SCU/ACP davranışıyla birleştiren derin Türkçe içerik **neredeyse yok**. Mevcut Türkçe içerik ya çeviri özetlerden ibaret ya da tek-CPU senaryosuyla sınırlı.
- **Saha gerçeği:** Aviyonik / emniyet kritik dünyada Zynq-7000 yaygın bir SoC; ekipler `volatile`-ile-paylaşım hatasını DMB serpiştirerek "çözmeye" çalışır, ama gerçek sebep MMU sayfa attribute hatası, ACP yerine HP/GP port seçimi, veya SCU snoop'un kapsam dışında kalan bir sayfa olabiliyor.
- **Standart yorumu:** ISO/IEC 9899:2011 §6.7.3'ün "volatile semantiği" ile §7.17'nin "atomik semantiği" arasındaki fark dışarıdan açık değildir; bu yazı iki maddeyi yan yana koyup ARMv7-A bellek modeliyle eşler.
- **Mevcut ekosistemle çakışmıyor:** Açık PR'lardaki MC/DC, CRC, VOR, watchdog, linker script, WCET, FTA, bellek güvenliği konularıyla örtüşmüyor. Son üç yayın (sistem, RF/DSP, gömülü/SoC) farklı alanlarda.
- **Doğal devam:** Daha önce yayımlanan [Renode ile Zynq7000 Simülasyonu](https://karaman.dev/2026/05/14/renode-ile-zynq7000-simulasyonu.html) yazısının yazılım eşzamanlılığı yanını tamamlıyor.

## Derinlik öğesi (Bölüm 7)

**Assembly inspection + sistem mimarisi haritası.** `arm-none-eabi-gcc -O2 -mcpu=cortex-a9 -marm` ile aynı RMW operasyonunun üç versiyonu derleniyor:

- `volatile uint32_t v_counter; v_counter++;` → 3 ardışık `LDR/ADD/STR` (yarış koşuluna açık, bariyer yok).
- `atomic_fetch_add_explicit(&a_counter, 1, memory_order_relaxed);` → `LDREX/STREX` döngüsü (ARMv7-A exclusive monitor + SCU snoop ile yarış-güvenli).
- `atomic_fetch_add_explicit(&a_counter, 1, memory_order_seq_cst);` → RMW döngüsünün önüne ve arkasına `DMB ISH` ekleniyor (SCU coherency garanti).

Ayrıca Zynq-7000'in üç koherans bölgesi (SCU snoop, ACP koherent, HP/GP non-koherent) bir Mermaid blok şemasıyla gösteriliyor; her birinin `volatile` / `_Atomic` / cache maintenance sorumluluğu net bir tabloyla ortaya konuyor.

## "Bu konuyu bulmak neden zor?"

- İngilizcede temel kaynaklar dağınık (kernel docs, CERT, LWN, ARM ARM, ISO standardı, Xilinx UG585, AMD Wiki).
- Türkçe içerik genellikle "volatile demek bellek değişebilir demektir" seviyesinde kalıyor; atomicity vs ordering ayrımı işlenmiyor.
- Zynq özelinde SCU'nun shareability domain ile çalıştığı, yanlış MMU attribute'unun LDREX/STREX'i sessizce bozduğu bilgisi nadiren tek bir yerde yazıyor.
- ACP'nin "cache flush'tan kurtaran yol" olduğu performans argümanı genelde Xilinx blog yazılarında dağınık; mühendislik kararı bağlamı yok.

## Kullanılan başlıca kaynaklar

- ISO/IEC 9899:2011 §6.7.3 ve §7.17 (N1570 taslak)
- [Linux kernel: volatile-considered-harmful.rst](https://www.kernel.org/doc/html/next/process/volatile-considered-harmful.html)
- [SEI CERT C: CON02-C](https://wiki.sei.cmu.edu/confluence/x/utYxBQ)
- [cppreference `<stdatomic.h>`](https://en.cppreference.com/w/c/header/stdatomic.html)
- [LWN: The trouble with volatile (Corbet, 2007)](https://lwn.net/Articles/233479/)
- [Embedded.com: Jack Ganssle, "C keywords: Don't flame out over volatile"](https://www.embedded.com/c-keywords-dont-flame-out-over-volatile/)
- ARM ARMv7-A & ARMv7-R Reference Manual (DDI 0406C.d), §A3.4 ve §A3.8
- [Cortex-A9 MPCore Technical Reference Manual (DDI 0407)](https://www.cl.cam.ac.uk/research/srg/han/ACS-P35/zynq/Cortex-A9-MPCore-TRM.pdf)
- Xilinx UG585 — Zynq-7000 SoC Technical Reference Manual
- [AMD/Xilinx Wiki — Ethernet Packet Inspection / ACP Tech Tip](https://xilinx-wiki.atlassian.net/wiki/display/A/Zynq-7000+AP+SoC+-+Performance+-+Ethernet+Packet+Inspection+-+Bare+Metal+-+Redirecting+Headers+to+PL+and+Cache+Tech+Tip)
- Hans-J. Boehm, "Threads Cannot Be Implemented as a Library", PLDI 2005

## Öz-eleştiri özeti

- ✅ Tek-core M4 senaryosundan SMP Cortex-A9'a geçişle birlikte DMB'nin "gereksiz"den "şart"a döndüğü vurgulandı.
- ✅ SCU snoop'un sayfa attribute (Inner Shareable + Cacheable) gerektirdiği, BSP'nin Xil_SetTlbAttributes ile bu garantiyi nasıl bozabileceği eklendi.
- ✅ ACP vs HP/GP ayrımı blok şema + tablo ile netleştirildi; pratik mühendislik kararına dönüştürüldü.
- ✅ Linus Torvalds doğrudan alıntısı kernel dokümanından paraphrased özete dönüştürüldü.
- ⚠ Kelime sayısı 3,805 (hedef bantın biraz üstünde) — Zynq spesifik kazanım için kabul edildi.
- ⚠ `memory_order_seq_cst (5)` numarası GCC enum değerine bağlı; pedagojik olarak bırakıldı.

## Yayın akış kontrolü

- Dal: `post/2026-05-29-volatile-yetmediginde-c11-atomic`
- Dosya: `_posts/2026-05-29-volatile-yetmediginde-c11-atomic.md`
- Front matter mevcut yazıların şemasıyla aynı (`mermaid: true` dahil)
- Kelime sayısı: ~3,800
- `master`'a doğrudan push yok
- Gizlilik kontrolü: yalnızca kamuya açık standart, kernel docs, ARM ARM, Xilinx UG585, AMD Wiki kaynaklı; proje-spesifik veya ihracat-kontrollü içerik yok

🤖 Generated with [Claude Code](https://claude.com/claude-code)