### PR TITLE
Add Plausible Analytics support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,10 @@ google_analytics:   G-YDEV31NZ5J
 # Found in Sentry: Settings → Projects → <project> → Client Keys (DSN) → Loader Script
 sentry_loader_id:   d9df60c4bcc41adb14bb648db4013b52
 
+# Add your Plausible site snippet ID here to activate Plausible Analytics
+# Found in Plausible: Site Settings → General → Site Installation (the pa-<ID> in the script src)
+plausible_id:       BMAxUwrIK8Icg2HpLysj2
+
 # Build settings
 markdown:           kramdown
 paginate:           5

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
 {% favicon %}
 {% seo %}
 {% include sentry.html %}
+{% include plausible.html %}
 <script>
   // No-flash dark mode: applies the saved theme before paint.
   (function () {

--- a/_includes/plausible.html
+++ b/_includes/plausible.html
@@ -1,0 +1,9 @@
+{% if site.plausible_id and site.plausible_id != "YOUR_PLAUSIBLE_ID_HERE" %}
+<!-- Privacy-friendly analytics by Plausible -->
+<script defer src="https://plausible.io/js/pa-{{ site.plausible_id }}.js"></script>
+<script>
+  window.plausible = window.plausible || function () { (window.plausible.q = window.plausible.q || []).push(arguments) };
+  window.plausible.init = window.plausible.init || function (i) { window.plausible.o = i || {} };
+  plausible.init();
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary

Adds privacy-friendly [Plausible Analytics](https://plausible.io) alongside the existing Google Analytics, following the same "ID in config + guarded include" pattern already used for Sentry.

## Changes

- **`_includes/plausible.html`** (new): Plausible's current per-site snippet, loaded as `https://plausible.io/js/pa-<ID>.js` with the lightweight `window.plausible` queue stub and `plausible.init()` call. Wrapped in an `{% if %}` guard so it only renders when an ID is configured.
- **`_config.yml`**: new `plausible_id` key (with explanatory comments mirroring the existing Sentry block).
- **`_includes/head.html`**: pulls in `plausible.html` from `<head>`, right next to the Sentry include — Plausible's recommended placement.

## Notes

- Uses the new per-site snippet format where the ID is embedded in the script path (`pa-<ID>.js`); no `data-domain` attribute is needed.
- To disable, simply blank out / remove `plausible_id` in `_config.yml`.

## Verification

`bundle exec jekyll build` renders the snippet into the `<head>` of every generated page. The build's only error in this environment is the unrelated `jekyll-favicon` / ImageMagick step, which CI installs via `pre_build_commands`.

https://claude.ai/code/session_012ZNdRz8LAmWVRXRg2dKbxq

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZNdRz8LAmWVRXRg2dKbxq)_