### PR TITLE
Stop loading compromised polyfill.io; add Content-Security-Policy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,3 +55,15 @@ plugins:
   - jekyll-spaceship
   - jekyll-favicon
   - jekyll-coffeescript
+
+# jekyll-spaceship — override the MathJax loader so it no longer injects the
+# compromised polyfill.io CDN (June 2024 supply-chain attack; see Qualys
+# advisory). The plugin's default `src` array hardcodes
+# https://polyfill.io/v3/polyfill.min.js, which it adds to the <head> of every
+# page containing math. MathJax 3 needs no polyfill on any currently supported
+# browser, so we keep only the jsDelivr-hosted MathJax bundle. The array fully
+# replaces the gem default, removing the polyfill.io <script> from the build.
+jekyll-spaceship:
+  mathjax-processor:
+    src:
+      - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,10 @@
 <head>
+<meta charset="utf-8">
+<!-- Content Security Policy: defense-in-depth against supply-chain script
+     injection (e.g. the polyfill.io attack). script-src is an explicit
+     allowlist of the CDNs this site actually uses, so any unlisted external
+     script (such as polyfill.io) is blocked by the browser. -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://cdn.plot.ly https://plausible.io https://js.sentry-cdn.com https://browser.sentry-cdn.com https://*.disqus.com https://*.disquscdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.disquscdn.com; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net https://*.disquscdn.com; img-src 'self' data: https:; connect-src 'self' https://plausible.io https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://*.sentry.io https://*.disqus.com https://*.disquscdn.com; frame-src 'self' https://disqus.com https://*.disqus.com https://www.youtube.com https://www.youtube-nocookie.com; worker-src 'self' blob:; manifest-src 'self'; form-action 'self' https://formspree.io">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {% favicon %}
 {% seo %}


### PR DESCRIPTION
## Problem

`jekyll-spaceship` (0.10.2) ships a MathJax processor whose default `src` hardcodes:

```
https://polyfill.io/v3/polyfill.min.js?features=es6
```

It injects that `<script>` into the `<head>` of **every page that contains math**. `polyfill.io` was taken over in the [June 2024 supply-chain attack](https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack) and began serving malicious JavaScript. Because the script is added at *build time* by the plugin, it isn't visible in the repo source — but the **live site was loading attacker-controlled code** on math posts (e.g. `kalman-filtresi`, `bandpass-sampling`).

## Fix

**1. Remove the polyfill.io injection** — `_config.yml`

Override the plugin's `mathjax-processor.src`. The plugin's array `src` *replaces* the gem default, so this drops `polyfill.io` and keeps only the jsDelivr-hosted MathJax bundle. MathJax 3 needs no polyfill on any currently supported browser.

```yaml
jekyll-spaceship:
  mathjax-processor:
    src:
      - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
```

**2. Defense-in-depth CSP** — `_includes/head.html`

A `Content-Security-Policy` meta tag whose `script-src` is an explicit allowlist of the CDNs this site actually uses, so any unlisted external script (including `polyfill.io`) is blocked by the browser even if reintroduced. The allowlist was derived from a full build and covers every external origin the site loads: GA, Plausible, Sentry, Cloudflare (Mermaid), Plotly, jsDelivr (MathJax), Google Fonts, Disqus, YouTube embeds, and Formspree.

## Verification

Local `jekyll build`:
- ✅ No `polyfill.io` URL anywhere in `_site` (only an explanatory comment).
- ✅ MathJax still loads on math posts (`cdn.jsdelivr.net/npm/mathjax@3/...`).
- ✅ CSP present on all 31 pages.
- ✅ Every external resource origin in the build is covered by the policy — no self-inflicted breakage.

Post-merge, the live site will be re-checked to confirm `polyfill.io` is gone and the CSP header is served.

https://claude.ai/code/session_01HncVHReQjWGVoLyguKDEWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01HncVHReQjWGVoLyguKDEWm)_