### PR TITLE
Kalman yazısı: mermaid syntax hatası ve render olmayan formülleri düzelt

### DIFF
--- a/_posts/2026-06-02-kalman-filtresi.md
+++ b/_posts/2026-06-02-kalman-filtresi.md
@@ -100,7 +100,7 @@ Buradaki `q` skaler bir "süreç gürültüsü yoğunluğu"dur ve birazdan en kr
 Filtre iki adımlı bir danstır. İlk adım **tahmin**: mevcut durumu ve belirsizliği, modeli kullanarak bir adım ileri taşırız.
 
 $$
-\hat{x}_k^- = F\,\hat{x}_{k-1} + B\,u_{k-1}
+\hat{x}\_k^- = F\,\hat{x}\_{k-1} + B\,u_{k-1}
 $$
 
 $$
@@ -166,9 +166,9 @@ flowchart LR
     subgraph GUNC["② GÜNCELLEME (Update)"]
       UPD["y = z − H·x⁻<br/>K = P⁻·Hᵀ·S⁻¹<br/>x = x⁻ + K·y<br/>P = (I − K·H)·P⁻<br/>(belirsizlik azalır)"]
     end
-    PRED -->|"a priori tahmin"| UPD
+    PRED -->|a priori tahmin| UPD
     Z(["ölçüm z"]) --> UPD
-    UPD -->|"a posteriori kestirim"| PRED
+    UPD -->|a posteriori kestirim| PRED
     UPD --> OUT["çıktı: x , P"]
     style INIT fill:#e8eef7,stroke:#4a6fa5,stroke-width:2px
     style PRED fill:#cee0f3,stroke:#3a5f95,stroke-width:2px
@@ -402,7 +402,7 @@ $$
 EKF adımları:
 
 $$
-\hat{x}_k^- = f(\hat{x}_{k-1}, u_{k-1}), \qquad P_k^- = F_k\,P_{k-1}\,F_k^{\mathsf{T}} + Q
+\hat{x}\_k^- = f(\hat{x}\_{k-1}, u_{k-1}), \qquad P_k^- = F_k\,P_{k-1}\,F_k^{\mathsf{T}} + Q
 $$
 
 $$


### PR DESCRIPTION
Kalman Filtresi yazısının **gerçek tarayıcıda (Playwright/Chromium) doğrulanan** iki render hatasını düzeltir.

> Not: PR #107 yalnızca ana sayfa thumbnail'ini (`sm/9.webp`) içeriyordu ve master'a merge edildi. Bu render düzeltmeleri o merge'den sonra eklendiği için ayrı bir PR olarak açıldı.

## 1. Mermaid "Syntax error in text" (mermaid 11.12.0)

İlk akış diyagramının pipe kenar etiketleri tırnaklıydı (`-->|"a priori tahmin"|`). Build sırasında tırnaklar `\"` olarak kaçışlanıyor, mermaid ayrıştıramayıp hata kutusu basıyordu. Etiketler yalnızca harf+boşluk içerdiğinden tırnaklar kaldırıldı (diğer çalışan diyagramlarla aynı stil).

## 2. İki formül ham `$$...$$` görünüyordu (MathJax render etmiyordu)

kramdown, `\hat{x}_k^- … \hat{x}_{k-1}` dizisindeki alt çizgileri markdown italik (`<em>`) sanıp tüketiyordu; araya giren `<em>` `$$…$$` bütünlüğünü bozduğundan MathJax bu iki bloğu eşleştiremiyordu. Sorunlu alt çizgiler `\_` ile kaçışlandı (kramdown bunu daima düz `_` üretir). Kelime-içi alt çizgiler (`x_k`, `P_k`) zaten güvenli; yalnızca bu iki blok etkileniyordu.

## Doğrulama (Playwright/Chromium, canlı → yerel düzeltilmiş build)

| Metrik | Önce | Sonra |
|---|---|---|
| Mermaid hata kutusu | 1 | 0 |
| Render olan diyagram | 1/2 | 2/2 |
| Render olan math (mjx-container) | 20 | 22 |
| Ham görünen `$$` | 4 | 0 |

`bundle exec jekyll build` yerelde başarıyla geçti.

https://claude.ai/code/session_01UfQqu4pADXWoqdWDskQ6Fp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfQqu4pADXWoqdWDskQ6Fp)_