### PR TITLE
Ana sayfa ve yazı linklerinden .html uzantısını kaldır

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -35,7 +35,7 @@ layout: default
           {% assign card_image = post.background | default: '/img/posts/1.webp' %}
           {% assign card_image_sm = card_image | replace: '/img/posts/', '/img/posts/sm/' %}
           <article class="post-card">
-            <a class="post-card__media" href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
+            <a class="post-card__media" href="{{ post.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
               {% if card_image contains '/img/posts/' %}
               <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}"
                    srcset="{{ card_image_sm | prepend: site.baseurl | replace: '//', '/' }} 768w, {{ card_image | prepend: site.baseurl | replace: '//', '/' }} 1600w"
@@ -47,7 +47,7 @@ layout: default
             </a>
             <div class="post-card__body">
               <h2 class="post-card__title">
-                <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">{{ post.title }}</a>
+                <a href="{{ post.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ post.title }}</a>
               </h2>
               <p class="post-card__subtitle">
                 {% if post.subtitle %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,14 +40,14 @@ layout: default
 
         <nav class="post-nav" aria-label="Yazı navigasyonu">
           {% if page.previous.url %}
-          <a class="post-nav__item post-nav__item--prev" href="{{ page.previous.url | prepend: site.baseurl | replace: '//', '/' }}">
+          <a class="post-nav__item post-nav__item--prev" href="{{ page.previous.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}">
             <span class="post-nav__direction">&larr; Önceki yazı</span>
             <span class="post-nav__title">{{ page.previous.title }}</span>
             <span class="post-nav__date">{% include tr-month.html date=page.previous.date %}</span>
           </a>
           {% endif %}
           {% if page.next.url %}
-          <a class="post-nav__item post-nav__item--next" href="{{ page.next.url | prepend: site.baseurl | replace: '//', '/' }}">
+          <a class="post-nav__item post-nav__item--next" href="{{ page.next.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}">
             <span class="post-nav__direction">Sonraki yazı &rarr;</span>
             <span class="post-nav__title">{{ page.next.title }}</span>
             <span class="post-nav__date">{% include tr-month.html date=page.next.date %}</span>
@@ -56,6 +56,12 @@ layout: default
         </nav>
 
         <div class="clearfix" id="disqus_thread"></div>
+          <script>
+            // Yorumları .html kanonik URL'sine sabitle; uzantısız adreste de aynı dizi yüklensin
+            var disqus_config = function () {
+              this.page.url = "{{ page.url | prepend: site.url }}";
+            };
+          </script>
           <script>
             (function () {
               var loaded = false;

--- a/posts/index.html
+++ b/posts/index.html
@@ -9,12 +9,12 @@ lang: tr
   {% for post in paginator.posts %}
   {% assign card_image = post.background | default: '/img/posts/1.webp' %}
   <article class="post-card">
-    <a class="post-card__media" href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
+    <a class="post-card__media" href="{{ post.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
       <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}" alt="" loading="lazy">
     </a>
     <div class="post-card__body">
       <h2 class="post-card__title">
-        <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">{{ post.title }}</a>
+        <a href="{{ post.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ post.title }}</a>
       </h2>
       <p class="post-card__subtitle">
         {% if post.subtitle %}


### PR DESCRIPTION
Ana sayfadan (ve yazı listesi + önceki/sonraki gezinmeden) tıklanan yazılarda URL'de gereksiz `.html` uzantısı görünüyordu. Linkler artık uzantısız üretiliyor.

## Değişiklikler
- `_layouts/home.html`, `posts/index.html`, `_layouts/post.html`: post linklerine `| remove: '.html'` eklendi (6 link).
- `_layouts/post.html`: Disqus, kanonik `.html` URL'sine sabitlendi (`disqus_config`) — uzantısız adreste mevcut yorumların kopmaması için.

## Neden güvenli
- Gerçek `.html` dosyaları, SEO `canonical`, sitemap ve RSS feed değişmedi → eski/indekslenmiş `.html` linkleri çalışmaya devam eder.
- GitHub Pages `slug.html`'i `slug` olarak da sunduğu için uzantısız adres zaten açılıyor (sitedeki `about` linki de zaten uzantısızdı).

🤖 Generated with [Claude Code](https://claude.com/claude-code)