### PR TITLE
Yazı arşivinde sayfa başına yazı sayısını 10'a çıkar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ plausible_id:       BMAxUwrIK8Icg2HpLysj2
 
 # Build settings
 markdown:           kramdown
-paginate:           5
+paginate:           10
 paginate_path:      "/posts/page:num/"
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Ana sayfa sabit 5 yazı göstermeye devam ederken (layout paginator
kullanmıyor, `limit: 5` ile sabit), /posts arşivinde `paginate`
değeri 5'ten 10'a çıkarıldı. Böylece "Eski yazılar" ile gezilen
arşiv sayfalarında sayfa başına 10 yazı listelenir.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
