### PR TITLE
Coupling yazısının tarihini bugüne çek (yayınlanması için)

### DIFF
--- a/_posts/2026-06-04-coupling-dengesi.md
+++ b/_posts/2026-06-04-coupling-dengesi.md
@@ -2,7 +2,7 @@
 title: "Coupling'i Dengelemek: Yazılım Tasarımında Bağımlılığı Yönetmek"
 subtitle: "Balancing Coupling in Software Design"
 background: "/img/posts/coupling-dengesi-cover.webp"
-date: '2026-06-09 09:00:00'
+date: '2026-06-04 09:00:00'
 layout: post
 lang: tr
 mermaid: true


### PR DESCRIPTION
[#115](https://github.com/Mavrikant/mavrikant.github.io/pull/115) ile eklenen yazı `2026-06-09` (gelecek) tarihliydi. `_config.yml`'de `future: true` ayarı olmadığından Jekyll bu yazıyı derlemede atlıyor ve siteye koymuyordu (canlıda 404).

Tarih bugüne (`2026-06-04`) çekildi; dosya `_posts/2026-06-04-coupling-dengesi.md` olarak yeniden adlandırıldı. Yeni URL: `/2026/06/04/coupling-dengesi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)