### PR TITLE
DO-178C Mermaid diyagramındaki sözdizimi hatasını düzelt

### DIFF
--- a/_posts/2026-06-04-coupling-dengesi.md
+++ b/_posts/2026-06-04-coupling-dengesi.md
@@ -194,7 +194,7 @@ flowchart LR
     subgraph B["Bileşen B"]
       BI["iç mantık"]
     end
-    A ==>|"kontrol bağlaşımı: çağrı / dönüş"| B
+    A == "kontrol bağlaşımı: çağrı / dönüş" ==> B
     A -. "veri bağlaşımı: paylaşılan veri" .-> B
     style AI fill:#e8eef7,stroke:#4a6fa5,stroke-width:2px
     style BI fill:#e8eef7,stroke:#4a6fa5,stroke-width:2px


### PR DESCRIPTION
DO-178C bölümündeki Mermaid diyagramı canlıda **syntax error** veriyordu.

**Sebep:** Kalın kenarda boru-etiket formu (`A ==>|"..."| B`) vardı. Jekyll build (jekyll-spaceship tablo işleyicisi) borulu satırdaki tırnakları ters-eğik çizgiyle kaçırıp `==>|\"...\"|` üretiyor; bu da Mermaid ayrıştırıcısını kırıyor. (Diğer diyagram boru-etiket içermediği için sağlamdı.)

**Çözüm:** Etiketi, build tarafından bozulmayan **orta-form**'a (`A == "..." ==> B`) çevirdim. Noktalı kenar zaten orta-form olduğu için sağlamdı.

Tarayıcıda `mermaid.render` ile doğrulandı: bozuk form parse error veriyor, yeni form sorunsuz render oluyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)