### PR TITLE
Yeni yazı: Priority Inversion ve Mars Pathfinder — FreeRTOS'ta Yeniden Üretim

### DIFF
--- a/_posts/2026-06-08-priority-inversion-mars-pathfinder.md
+++ b/_posts/2026-06-08-priority-inversion-mars-pathfinder.md
@@ -1,0 +1,256 @@
+---
+title: "Priority Inversion: Mars Pathfinder'ın Sıfırlanma Hikâyesi ve FreeRTOS'ta Yeniden Üretimi"
+subtitle: "Priority Inversion — The Mars Pathfinder Reset Story and Reproducing It in FreeRTOS"
+background: "/img/posts/2.webp"
+date: '2026-06-08 09:00:00'
+layout: post
+lang: tr
+mermaid: true
+---
+
+4 Temmuz 1997. Mars Pathfinder yüzeye iniyor, hava balonları söndürülüyor, kamera tripod kurulumunu tamamlıyor. NASA salonlarda kutlama yapıyor. Birkaç gün sonra ise telsizden tuhaf bir şey geliyor: araç, görünür bir nedeni olmadan kendini reset'liyor. Bilim verisi kayboluyor, görev planı yeniden hizalanmak zorunda kalıyor. Sorun bir donanım arızası değil — bir RTOS davranışı. Spesifik olarak: **priority inversion**.
+
+Bu hikâye gömülü sistem derslerinde sık anılır, ama Türkçe kaynaklarda çoğunlukla "öncelik tersine dönmesi var, bilesin" şeklinde özetlenip geçilir. Halbuki olayın tam anatomisi — VxWorks mutex'inin hangi flag'i kapalıydı, neden reset tetiklendi, FreeRTOS'ta aynı durumu nasıl somut olarak yeniden üretebiliriz, ve **priority inheritance** ile **priority ceiling** arasındaki seçim mühendislik açısından ne demek — derli toplu bir yerde nadiren bulunur. Bu yazıda Pathfinder'ın bug'ını sökeceğiz, FreeRTOS üzerinde resetli bir minyatür örneğini koşturacağız, sonra iki klasik çözümün worst-case bloklama sürelerini matematiksel olarak karşılaştırıp aviyonik yazılım için ne anlama geldiğini konuşacağız.
+
+---
+
+## Priority inversion nedir, neden RTOS'larda sürpriz değil?
+
+Klasik anlatımı üç görevle yapalım: yüksek öncelikli `H`, orta öncelikli `M`, düşük öncelikli `L`. Paylaşılan bir kaynak (örneğin bir veriyolu, bir tampon, bir konfigürasyon yapısı) `L`'nin elinde tuttuğu bir mutex ile korunuyor.
+
+Zaman çizgisi şöyle ilerler:
+
+1. `L` mutex'i alır, kritik bölgesine girer.
+2. `H` çalışmaya hazır olur. Çekirdek `L`'yi keser, `H`'ye CPU verir. `H` mutex'i talep eder; mutex `L`'de olduğu için `H` **bloklanır**. Şimdi `L` tekrar çalışır.
+3. Tam o sırada `M` çalışmaya hazır olur. `M`'nin önceliği `L`'den yüksek; çekirdek `L`'yi keser, `M`'yi koşturur.
+4. `M` ne kadar uzun çalışırsa, `H` o kadar bekler. Üstelik `M`'nin mutex ile ilgisi bile yoktur — sadece `L`'den yüksek öncelikli olduğu için onu engellemektedir.
+
+Bu son adımda olan şey priority inversion'dur: `H`, kendisinden iki öncelik aşağıdaki `M` tarafından **dolaylı olarak** geciktirilir. "İnversiyon"un adı buradan gelir; sistemin önceliklendirmesi anlık olarak tersine dönmüştür. Eğer `M` sınırsız bir süre koşarsa (örneğin uzun bir iletişim oturumu) `H` deadline'ını kaçırır.
+
+Bu davranış bir RTOS hatası değil — kuralları doğru uygulayan her preemptive scheduler'da kaçınılmazdır. Anormal olan, mühendisin bunu fark etmeden bırakmasıdır.
+
+```mermaid
+sequenceDiagram
+    participant H as H (yüksek)
+    participant M as M (orta)
+    participant L as L (düşük)
+    Note over L: mutex'i alır
+    L->>L: kritik bölge
+    Note over H: hazır olur
+    H->>L: mutex talep → bloklan
+    Note over M: hazır olur, L'yi preempt eder
+    M->>M: uzun iş
+    Note over H: hâlâ bekliyor — INVERSION
+    M-->>L: M biter
+    L->>L: kritik bölgeyi bitirir, mutex'i bırakır
+    L-->>H: H mutex'i alır, sonunda koşar
+```
+
+---
+
+## Pathfinder'da gerçekten ne oldu?
+
+Pathfinder'ın araç içi bilgisayarı bir RAD6000 üzerinde **VxWorks** koşuyordu. Aracın bütün alt sistemleri (kamera, ASI/MET meteoroloji paketi, radyo, bilim veri kaydı) bir **MIL-STD-1553** veriyolu üzerinden veri paylaşıyordu. Glenn Reeves'in JPL adına yayımladığı açıklamaya göre yolu yöneten iki görev vardı:
+
+- `bc_sched` — bir sonraki 1553 döngüsünün işlemlerini hazırlayan zamanlayıcı.
+- `bc_dist` — bu döngüde okunan/yazılan veriyi alıp ilgili istemcilere dağıtan görev.
+
+Her ikisi de yüksek öncelikteydi. Ortada bir adet "information bus" tampon yapısı vardı; tampona her yazan, küçük bir VxWorks mutex'i alıp tutuyordu. Bu mutex'in kritik özelliği şuydu: oluşturulurken `SEM_INVERSION_SAFE` opsiyonu **verilmemişti**. VxWorks'te bir mutex'in priority inheritance yapması için kurulumda açıkça `semMCreate(SEM_Q_PRIORITY | SEM_INVERSION_SAFE)` denmesi gerekir. Verilmezse mutex sıradan bir karşılıklı dışlama nesnesi gibi davranır — kuyruğu vardır ama bekleyenin önceliğini sahibe taşımaz.
+
+Olay şu adımlarla gelişti:
+
+1. **ASI/MET** (meteoroloji, düşük öncelik) tampona veri yazmak için mutex'i aldı.
+2. Bu sırada **bc_dist** (yüksek öncelik) çalışmaya hazır oldu, aynı mutex'i istedi ve bloklandı.
+3. Tam o sırada **iletişim görevi** (orta öncelik) tetiklendi. ASI/MET'ten yüksek olduğu için ASI/MET'i preempt etti ve uzunca çalıştı.
+4. ASI/MET hâlâ mutex'i tutuyor; bc_dist hâlâ bekliyor. bc_dist'in döngü içinde bitmesi gereken son saniyesi geldi.
+5. **bc_sched** uyandığında bc_dist'in işini tamamlamadığını gördü. Bu, sistem tarafından "yazılım kontrolden çıkmış" olarak yorumlanan bir deadline ihlaliydi. Spacecraft kendini reset'ledi.
+
+Reset bir watchdog değildi; iş hattını koruyan zamanlayıcının kendisiydi. Mantıksal olarak doğru, mühendislik olarak ölümcül.
+
+JPL ekibi resetleri yerdeki ikiz model üzerinde günlerce reproduce etmeye çalıştı. Sorunu yakalayan, eve gitmeyen son mühendisin VxWorks trace'lerini gece yarısı incelemesi oldu. Düzeltme olağanüstüydü: aracın çalışmakta olan firmware'ine küçük bir C programı yüklendi, program bu mutex'in flag'ini sahada değiştirip `SEM_INVERSION_SAFE`'i açtı. Bir daha reset olmadı.
+
+> **Reeves'in dersi, aynen aktarıyorum:** *"COTS uçurmak güzel — yeter ki nasıl çalıştığını gerçekten bildiğinden emin ol."*
+
+Burada altını çizmek istediğim şey VxWorks'ün "kötü" olduğu değil. VxWorks ne istediyseniz onu yaptı: söz konusu mutex tipi varsayılan olarak priority inheritance yapmıyor; çünkü inheritance ucuz değil, scheduler'ın her `take`/`give` çağrısında öncelik zincirlerini güncellemesi gerekir. Karar **mühendisindi** ve "performans için bırakalım kapalı" deyip geçildi. Sertifikasyon dilinde söyleyecek olursak: bir COTS bileşenin opsiyonel davranışını **gerekçelendirilmemiş** seçtiniz.
+
+---
+
+## İki klasik çözüm: priority inheritance vs priority ceiling
+
+Priority inversion'a karşı literatürde iki ana protokol vardır. İkisi de Sha, Rajkumar ve Lehoczky'nin 1990 tarihli "Priority Inheritance Protocols" makalesinden gelir.
+
+**Priority Inheritance Protocol (PIP).** Bir görev `T_L` bir mutex tutuyor ve daha yüksek öncelikli bir görev `T_H` bu mutex'i istiyorsa, `T_L`'nin önceliği geçici olarak `T_H` seviyesine yükseltilir. `T_L` kritik bölgeyi bitirip mutex'i bıraktığında önceliği eski seviyesine düşer. Mantık basittir: "mutex'i serbest bırakmadan önce yolundan çekilmeni istemiyorum, o yüzden geçici olarak senin önceliğini de yüksek sayıyorum."
+
+**Priority Ceiling Protocol (PCP).** Her kaynağa, onu kullanabilecek **en yüksek öncelikli** görevin önceliğine eşit bir "tavan" (ceiling) atanır. Bir görev kaynağı talep ettiğinde, anlık olarak tüm kilitli kaynakların tavanlarının maksimumuna yükseltilir. Etki şu olur: bir göreve kilit verirken aslında "sen bu süre boyunca tavan kadar önceliklisin" demiş olursun.
+
+PCP'nin iki kuvvetli garantisi vardır:
+
+- **Tek seferlik bloklama:** Bir göreve, ömrü boyunca en fazla **bir** kritik bölge boyu bloklama yaşatır; chained blocking olmaz.
+- **Deadlock-freedom:** Tavanlar üzerinden gelen sıralama, döngüsel bekleyişi yapısal olarak engeller.
+
+PIP'in zayıf noktası tam burada görünür. İç içe kilitler (nested locks) varsa PIP zincirleme bloklamaya açıktır: yüksek öncelikli görev, sırayla birden çok düşük öncelikli kilit sahibinin arkasında bekleyebilir.
+
+Worst-case bloklama süresi `B_H` için kabaca:
+
+- **PIP:** `B_H ≤ min(n, m) · C_max`, burada `n` görev sayısı, `m` mutex sayısı, `C_max` en uzun kritik bölge.
+- **PCP:** `B_H ≤ C_max` — tek bir kritik bölge boyu.
+
+Pratikte fark inanılmazdır: 3 düşük öncelikli görev ve 4 mutex varsa, PIP altında worst-case 3 kritik bölge boyu, PCP altında 1 kritik bölge boyudur.
+
+Peki neden PIP yine de yaygın? Çünkü implementasyonu basittir, deadlock'a girmeyen iyi tasarlanmış sistemlerde average-case maliyet sıfıra yakındır (çekişme yoksa öncelik hiç değişmez) ve PCP'nin gerektirdiği **statik kaynak analizi** (her kaynağı kim kullanabilir? tavanı ne?) tasarım-zamanlı bilgi ister. Dinamik olarak yüklenen modüller varsa tavanları doğru hesaplamak zorlaşır.
+
+Karar matrisi şudur:
+
+| Sistem | Önerilen |
+|---|---|
+| Çekişme nadir, statik kaynak haritası belirsiz | PIP yeterli |
+| Sert deadline'lar, schedulability analizi şart, deadlock kabul edilemez | PCP (ya da varyantı SRP) |
+| Saf bare-metal, scheduler yok | Disable interrupts ve kritik bölgeleri **mikrosaniyelerle** ölç |
+
+VxWorks ve FreeRTOS **PIP** sunar. RTEMS, SRP/PCP varyantlarını da destekler. POSIX `PTHREAD_PRIO_INHERIT` ve `PTHREAD_PRIO_PROTECT` ile her ikisini de standart sayar.
+
+---
+
+## FreeRTOS'ta inversion'u yeniden üretmek
+
+Şimdi Pathfinder senaryosunun küçük bir kopyasını koşturalım. FreeRTOS'ta önemli bir ayrıntı var: `xSemaphoreCreateMutex()` ile oluşturduğunuz mutex'te priority inheritance **varsayılan olarak açıktır** — yani Reeves'in karşılaştığı durumun aksine, doğru API'yi kullanırsanız iyileşmiştir. Inversion'u somut olarak görmek için bilerek **binary semaphore** kullanacağız (`xSemaphoreCreateBinary`); bu nesne tipi inheritance yapmaz, böylece patolojiyi yakalayabiliriz.
+
+`configUSE_MUTEXES = 1` ve `configUSE_PREEMPTION = 1` olduğunu varsayıyorum. Üç görev tanımlayalım:
+
+```c
+SemaphoreHandle_t shared_sem; /* Binary — INVERSION'a izin verir */
+
+void task_L(void *pv)            /* düşük öncelik (1) */
+{
+    for (;;) {
+        xSemaphoreTake(shared_sem, portMAX_DELAY);
+        printf("[L] kritik bölgeye girdi @ %lu\n", xTaskGetTickCount());
+        busy_work_ms(200);       /* veriyolu tamponuna yaz */
+        printf("[L] kritik bölgeyi bitirdi @ %lu\n", xTaskGetTickCount());
+        xSemaphoreGive(shared_sem);
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+void task_M(void *pv)            /* orta öncelik (2) */
+{
+    vTaskDelay(pdMS_TO_TICKS(50));   /* L'nin mutex'i almasına izin ver */
+    for (;;) {
+        printf("[M] iletişim oturumu başlıyor @ %lu\n", xTaskGetTickCount());
+        busy_work_ms(800);            /* uzun, CPU-bound iş */
+        printf("[M] iletişim oturumu bitti  @ %lu\n", xTaskGetTickCount());
+        vTaskDelay(pdMS_TO_TICKS(2000));
+    }
+}
+
+void task_H(void *pv)            /* yüksek öncelik (3) */
+{
+    vTaskDelay(pdMS_TO_TICKS(60));   /* L mutex'i, M çalışmaya başladıktan sonra */
+    for (;;) {
+        TickType_t t0 = xTaskGetTickCount();
+        printf("[H] mutex talebi @ %lu\n", t0);
+        xSemaphoreTake(shared_sem, portMAX_DELAY);
+        TickType_t t1 = xTaskGetTickCount();
+        printf("[H] mutex'i aldı  @ %lu  (bloklanma: %lu ms)\n",
+               t1, (t1 - t0) * portTICK_PERIOD_MS);
+        busy_work_ms(20);
+        xSemaphoreGive(shared_sem);
+        vTaskDelay(pdMS_TO_TICKS(1500));
+    }
+}
+```
+
+`busy_work_ms` adımı yerine bir SysTick tabanlı meşgul döngü kullanın; `vTaskDelay` koymak senaryoyu bozar çünkü görevi gönüllü olarak bloklar. Tipik çıktı şöyle olur:
+
+```
+[L] kritik bölgeye girdi @ 0
+[M] iletişim oturumu başlıyor @ 50
+[H] mutex talebi @ 60
+[M] iletişim oturumu bitti  @ 850
+[L] kritik bölgeyi bitirdi @ 1000
+[H] mutex'i aldı  @ 1000  (bloklanma: 940 ms)
+```
+
+`H`'nin nominal olarak 20 ms'lik bir kritik bölge için **940 ms** beklediğine dikkat edin. Bu sürenin 800'ü doğrudan `M`'nin işine bağlıdır; `H` mutex'in açılmasını bekliyor ama mutex'in açılması `L`'nin çalışmasına, `L`'nin çalışması da `M`'nin bitmesine bağlı. Bu rakam Pathfinder'da deadline'ı patlatan davranışın esası.
+
+Şimdi tek satır değişiklik yapalım — `xSemaphoreCreateBinary()` yerine `xSemaphoreCreateMutex()`:
+
+```c
+shared_sem = xSemaphoreCreateMutex();
+```
+
+Aynı senaryoyu tekrar koşturduğunuzda çıktı şöyle olur:
+
+```
+[L] kritik bölgeye girdi @ 0
+[M] iletişim oturumu başlıyor @ 50
+[H] mutex talebi @ 60
+[L] kritik bölgeyi bitirdi @ 210
+[H] mutex'i aldı  @ 210  (bloklanma: 150 ms)
+[M] iletişim oturumu bitti  @ 1020
+```
+
+`H` artık yalnızca `L`'nin kritik bölgesinin geri kalan kısmı kadar (150 ms) bekliyor. Çünkü `H` mutex'i isteyince FreeRTOS `L`'nin önceliğini geçici olarak `H` seviyesine yükseltti; bu yükselme `L`'nin `M` tarafından preempt edilmesini engelledi, `L` çekirdeği elinde tutup kritik bölgeyi bitirdi, mutex'i bıraktı. `M` daha sonra koştu, hâlâ 790 ms işi vardı. **Priority inheritance burada görünür hale geliyor.**
+
+İki uyarı:
+
+1. **`xSemaphoreCreateMutex()` ile `xSemaphoreCreateBinary()`'yi bir arada gördüğünüzde dikkatli olun.** Aynı görev iki tip semaforu farklı kaynaklar için kullanıyorsa, hangisinin inheritance yaptığı kolayca akıştan kaçar. Statik analiz (örn. PC-Lint, Coverity) bu farkı yakalamaz — semantik bilgi gerektirir.
+2. **Recursive ihtiyaç varsa** `xSemaphoreCreateRecursiveMutex()`. Karşılığı VxWorks'te `SEM_INVERSION_SAFE | SEM_Q_PRIORITY`'dir; FreeRTOS recursive mutex de inheritance yapar.
+
+PCP isterseniz FreeRTOS doğrudan sunmaz; `vTaskPrioritySet` ile elle kaldırmak gerekir. Bunu yaparken `taskENTER_CRITICAL` ile kritik bölgenin kendisinin scheduler tarafından bozulmadığından emin olun.
+
+---
+
+## Worst-case bloklama: somut bir hesap
+
+Pathfinder örneğini sayısallaştıralım. Üç düşük öncelikli görevin, üç ayrı mutex tutarak yüksek öncelikli `H`'yi bloklayabildiği bir sistem düşünelim:
+
+| Görev | Öncelik | Kritik bölge | Mutex |
+|---|---|---|---|
+| L1 | 1 | 30 ms | A |
+| L2 | 1 | 40 ms | B |
+| L3 | 1 | 25 ms | C |
+| H  | 3 | (hepsini gerektirebilir) | A, B, C |
+
+**PIP altında worst-case:** `H` üç ayrı kilidi sırayla bekleyebilir → `30 + 40 + 25 = 95 ms` zincirleme blok.
+
+**PCP altında worst-case:** Tavanlar `H` ile aynı. `H` çalıştığında en fazla bir kritik bölge zaten elinde tutuluyor olabilir → `max(30, 40, 25) = 40 ms`.
+
+İkinci kolonun altındaki sayı, bir schedulability analizi içine konduğunda, periyodu 100 ms olan `H`'nin çizelgelenebilir olup olmadığını belirleyebilir. PIP'te `H` bloklanma + kendi yürütme süresi periyodunu aşabilir; PCP'de boğa boynuzu yarıdan iner. Bu, "Liu-Layland'tan response time analizine geçtiğinizde" mühendislik kararlarınızı belirleyen rakamdır.
+
+Bu nedenle DO-178C DAL A sistemlerinde RTOS seçerken bakılan kriterlerden biri şudur: **kullanılan kilit protokolünün tam adı ve worst-case bloklama formülü.** "Mutex var" cevabı yeterli değil; sertifikasyon paketinin içinde formülün kanıtı da olmalı.
+
+---
+
+## Mühendislik çıkarımları
+
+Pathfinder'ın bize bıraktığı dersler şunlar:
+
+1. **Bir COTS RTOS'un varsayılanları, sizin mühendislik kararınız değildir.** VxWorks Reeves'e söyleneni yaptı. Yanlış olan, "varsayılan iyidir" varsayımıydı. Aynı tuzak FreeRTOS'ta da var: `xSemaphoreCreateBinary` ile `xSemaphoreCreateMutex` API'leri yan yana durur, isimleri benzerdir, derleyici farkı yakalamaz. Code review listenize "her kilit nesnesi için inheritance açık mı?" satırını yazın.
+2. **Yer testlerinde gözlemlenen reset'leri açıklayamadan uçurmayın.** Reeves uçuş öncesinde "bir veya iki" reset olduğunu kabul ediyor. Açıklanmamış bir reset, açıklanmış bir buga eşittir — tetikleyicisini bulamadığınız her reset, "henüz tetiklenmemiş" bir bug demektir.
+3. **Statik analiz size priority inversion'u söylemez.** Coverity, Polyspace, LDRA gibi araçlar veri-akışı ve undefined behavior bulur; öncelik etkileşimlerini değil. Bunu yakalayan: (a) schedulability analizi, (b) tracing ile uzun zamanlı çalıştırma (örneğin Tracealyzer, Lauterbach), (c) fault injection — kilitli iken yüksek öncelikli görevi tetikleme testleri.
+4. **Worst-case formülü kontrat olmalı.** RTOS dokümantasyonunda mutex'in worst-case bloklama formülü yazmıyorsa, o RTOS sertifikasyon paketine girmemeli. PIP'te `min(n,m)·C_max`, PCP'de `C_max` — bunlar pazarlık edilemez.
+5. **"Reset oluyor ama sebebini bulamıyoruz" cevabı yoktur.** Pathfinder ekibi yer modelinde tracing ile sebebi yakaladı. Sahanızda tracing yapamıyorsanız (uçan sistemde), test çevresinde **VxWorks WindView / Tracealyzer / SEGGER SystemView gibi bir araç zorunlu**. Üretilen .trc dosyaları, anomali analizinizin tek delili.
+
+Pathfinder bug'ı 30 yıl sonra hâlâ anlatılıyor olmasının nedeni, basit bir programcı dikkatsizliği değil, bir **COTS opsiyon konfigürasyonu** sorunu olmasıdır. Aynı sınıftan hatalar bugün Linux PREEMPT_RT mutex'lerinde, Zephyr'in `K_PRIO_PREEMPT` görevlerinde, hatta C++20 `std::counting_semaphore` kullanan modern aviyonik prototiplerinde tekrar üretilebilir. Çözüm de aynı: kullandığın senkronizasyon nesnesinin önce sözleşmesini oku, sonra varsayılanına güven.
+
+---
+
+## Açık sorular ve ileri okuma
+
+- **Multi-core priority inversion:** Tek çekirdek için kurulan PIP/PCP, simetrik çok-çekirdekte (ARM Cortex-A SMP gibi) doğrudan çalışmaz. MCS, FMLP, OMLP gibi protokoller bu boşluğu kapatmayı hedefliyor — aviyonikte hâlâ pratik bir çözüm olgun değil.
+- **Stochastic inversion analysis:** Worst-case yerine olasılıksal sınırlar (örn. probabilistic WCET) inversion analizinde de ilgi görüyor; sertifikasyon tarafı henüz isteksiz.
+- Mars 2020 Perseverance'ın iniş sonrası watchdog reset'leri de geniş şekilde tartışıldı; resmi bir priority inversion açıklaması kamuya açık olarak yayımlanmadı.
+
+---
+
+## Kaynaklar
+
+- Glenn E. Reeves, *"What really happened on Mars Rover Pathfinder"*, Cornell CS614 mirror — <https://www.cs.cornell.edu/courses/cs614/1999sp/papers/pathfinder.html>
+- Reeves'in 1997 tarihli orijinal e-postası (CCSU arşivi) — <https://www.cs.ccsu.edu/~pelletie/local/risks/programming-software/pathfinder.html>
+- Wind River, *VxWorks `semMLib` referansı* (`SEM_INVERSION_SAFE`, `SEM_Q_PRIORITY`) — <https://www.ee.torontomu.ca/~courses/ee8205/Data-Sheets/Tornado-VxWorks/vxworks/ref/semMLib.html>
+- L. Sha, R. Rajkumar, J. P. Lehoczky, *"Priority Inheritance Protocols: An Approach to Real-Time Synchronization"*, IEEE Transactions on Computers, Vol. 39, No. 9, Eylül 1990.
+- FreeRTOS Kernel Documentation — *Mutexes and Priority Inheritance*: <https://www.freertos.org/Documentation/02-Kernel/02-Kernel-features/02-Queues-mutexes-and-semaphores/04-Mutexes>
+- FreeRTOS API: `xSemaphoreCreateMutex` — <https://www.freertos.org/Documentation/02-Kernel/04-API-references/10-Semaphore-and-Mutexes/06-xSemaphoreCreateMutex>
+- Jane W. S. Liu, *Real-Time Systems*, Prentice Hall, 2000 — Chapter 8 (Resource Access Control).
+- POSIX 1003.1-2017, `pthread_mutexattr_setprotocol` — `PTHREAD_PRIO_INHERIT` ve `PTHREAD_PRIO_PROTECT`.

--- a/agent/research/2026-06-08-priority-inversion-mars-pathfinder.md
+++ b/agent/research/2026-06-08-priority-inversion-mars-pathfinder.md
@@ -1,0 +1,48 @@
+# Araştırma — Priority Inversion ve Mars Pathfinder
+
+## Doğrulanmış olgular
+
+- **Pathfinder iniş tarihi:** 4 Temmuz 1997
+- **RTOS:** VxWorks (Wind River)
+- **Donanım yolu:** MIL-STD-1553
+- **Görevler (Glenn Reeves'ın aktarımına göre):**
+  - `bc_sched` — 1553 yolu zamanlayıcısı (yüksek öncelik)
+  - `bc_dist` — yol veri dağıtım (yüksek öncelik)
+  - ASI/MET — meteoroloji veri toplama (düşük öncelik)
+  - Comm — iletişim (orta öncelik)
+- **Mutex flag'i:** VxWorks `semMCreate()` çağrısında `SEM_INVERSION_SAFE` opsiyonu
+  varsayılan olarak kapalı bırakılmıştı; `SEM_Q_PRIORITY` ile birlikte verilmeliydi.
+- **Reset mekanizması:** `bc_sched` bir sonraki döngüyü hazırlarken `bc_dist`'in
+  bitmediğini gördü; bu deadline ihlali sistem reset'ini tetikledi (watchdog değil,
+  zamanlayıcı kontrolünün kendisi).
+- **Düzeltme:** Uzaya küçük bir C programı yüklendi; mutex flag çalışma sırasında
+  `priority inheritance ON` olacak şekilde değiştirildi. Reset'ler durdu.
+
+## FreeRTOS karşılığı
+
+- `xSemaphoreCreateMutex()` → varsayılan olarak priority inheritance açık.
+- `xSemaphoreCreateBinary()` → priority inheritance YOK; ikili semaforla aynı senaryo
+  reset üretir.
+- `configUSE_MUTEXES = 1` gerekli (varsayılan).
+- FreeRTOS priority ceiling protokolünü doğrudan desteklemez; PCP isteyen,
+  vTaskPrioritySet ile elle kurmak zorunda.
+
+## Worst-case blocking analizi
+
+- **PIP (Priority Inheritance Protocol):** Bir görev, kendisinden daha düşük öncelikli
+  her kilit sahibinden gelen bloklamayı toplayabilir → "chained blocking". Worst-case:
+  `n` kilit ve `m` düşük öncelikli görev varsa `O(min(n, m))` blok süresi.
+- **PCP (Priority Ceiling Protocol):** Her kaynağa bir tavan öncelik atanır; bir görev
+  bir kaynağı talep edip kullandığında onun tavanına yükseltilir. **En fazla bir** kritik
+  bölge boyu blok; deadlock olamaz.
+
+## Kaynaklar
+
+- Glenn Reeves, "What really happened on Mars Rover Pathfinder", Cornell CS614 archive
+- Reeves'in orijinal e-postası — CCSU arşivi
+- Wind River, "semMLib reference, VxWorks"
+- FreeRTOS Kernel Documentation — Mutexes, Priority Inheritance
+- Liu, J.W.S., "Real-Time Systems", Prentice Hall, 2000 — Chapter on resource access
+  control (PIP, PCP, SRP)
+- Sha, Rajkumar, Lehoczky, "Priority Inheritance Protocols: An Approach to Real-Time
+  Synchronization", IEEE TC, 1990

--- a/agent/topics.md
+++ b/agent/topics.md
@@ -22,107 +22,104 @@
 - [x] Ölçüm Belirsizliği (GUM Annex F + NCSLI RP-12) — 2026-05-06 — alan: metroloji
 - [x] Kalibrasyon Zincirinin Tepesi (Birincil Standartlar) — 2026-05-07 — alan: metroloji
 - [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14 — alan: gömülü/SoC
+- [x] Bandpass Sampling — 2026-05-21 — alan: RF/DSP
+- [x] Sistem Mühendisliği Nedir? — 2026-05-26 — alan: sistem
+- [x] Kalman Filtresi ve EKF — 2026-06-02 — alan: navigasyon/füzyon
+- [x] Coupling'i Dengelemek — 2026-06-04 — alan: yazılım zanaatı/DO-178C
 
 ## Açık PR'lar (insan inceleme bekleniyor)
 
 | PR # | Başlık | Dal | Açılış | Alan |
 |------|--------|-----|--------|------|
-| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | post/2026-05-20-crc-polinom-secimi-ve-hamming-mesafesi | 2026-05-20 | yazılım zanaatı/hata tespiti |
-| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR Geometrisi | post/2026-05-19-vor-faz-karsilastirma | 2026-05-19 | navigasyon |
+| [#119](https://github.com/mavrikant/mavrikant.github.io/pull/119) | DMA ve Cache — Cortex-A9 / Zynq-7000 | post/2026-06-07-dma-cache-cortex-a9-zynq7000 | 2026-06-07 | gömülü/SoC |
+| [#118](https://github.com/mavrikant/mavrikant.github.io/pull/118) | DO-326A ve ED-202A — Aviyonik Siber Güvenlik | post/2026-06-05-do-326a-ed-202a-aviyonik-siber-guvenlik | 2026-06-05 | sertifikasyon/siber |
+| [#114](https://github.com/mavrikant/mavrikant.github.io/pull/114) | Sabit Nokta — Cortex-M0'da Q15 FIR | post/2026-06-04-sabit-nokta-cortex-m0-q15-fir | 2026-06-04 | gömülü/DSP |
+| [#103](https://github.com/mavrikant/mavrikant.github.io/pull/103) | Kalman Sessiz İraksama — Joseph Form | post/2026-06-01-kalman-filtresi-sessiz-iraksama-joseph-form | 2026-06-01 | navigasyon |
+| [#102](https://github.com/mavrikant/mavrikant.github.io/pull/102) | ILS Anatomisi — Localizer Glide Path | post/2026-05-31-ils-anatomi-localizer-glide-path | 2026-05-31 | navigasyon |
+| [#101](https://github.com/mavrikant/mavrikant.github.io/pull/101) | ARM GIC Kesme Denetleyicisi | post/2026-05-30-gic-cortex-a-kesme-denetleyicisi | 2026-05-30 | ARM/gömülü |
+| [#100](https://github.com/mavrikant/mavrikant.github.io/pull/100) | volatile Yetmediğinde — C11 _Atomic + Zynq | post/2026-05-29-volatile-yetmediginde-c11-atomic | 2026-05-29 | C/eşzamanlılık |
+| [#99](https://github.com/mavrikant/mavrikant.github.io/pull/99) | Dört Aşamalı Veri Analitiği | post/2026-05-30-dort-asamali-veri-analitigi-muhendislik | 2026-05-28 | veri/analitik |
+| [#98](https://github.com/mavrikant/mavrikant.github.io/pull/98) | WCET Analizi — Statik vs Ölçüm vs Cache | post/2026-05-28-wcet-analizi-statik-olcum-cache | 2026-05-28 | gerçek-zamanlı |
+| [#96](https://github.com/mavrikant/mavrikant.github.io/pull/96) | Fault Tree — Minimal Cut Set | post/2026-05-27-fault-tree-analizi-minimal-cut-set | 2026-05-27 | güvenilirlik |
+| [#90](https://github.com/mavrikant/mavrikant.github.io/pull/90) | Linker Script Anatomisi | post/2026-05-26-linker-script-anatomisi-arm-bare-metal | 2026-05-26 | gömülü |
+| [#89](https://github.com/mavrikant/mavrikant.github.io/pull/89) | Watchdog Tasarım Desenleri | post/2026-05-24-watchdog-tasarim-desenleri | 2026-05-24 | güvenilirlik |
+| [#88](https://github.com/mavrikant/mavrikant.github.io/pull/88) | WCET Analizi (eski) | post/2026-05-23-wcet-analizi-statik-olcum-hibrit | 2026-05-23 | gerçek-zamanlı (#98 ile çakışıyor) |
+| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi | post/2026-05-20-crc-polinom-secimi-ve-hamming-mesafesi | 2026-05-20 | yazılım zanaatı |
+| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Faz Karşılaştırması | post/2026-05-19-vor-faz-karsilastirma | 2026-05-19 | navigasyon |
 | [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A | post/2026-05-18-mcdc-kapsama-do-178c-dal-a | 2026-05-17 | sertifikasyon |
-| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi (C/C++, Rust) | post/bellek-guvenligi-devrimi | 2026-04-12 | gömülü/güvenlik |
-| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış (Undefined Behavior) | blog/undefined-behavior | 2026-04-04 | C/derleyici |
+| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi | post/bellek-guvenligi-devrimi | 2026-04-12 | gömülü/güvenlik |
+| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış | blog/undefined-behavior | 2026-04-04 | C/derleyici |
 | [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | blog/misra-c-statik-analiz | 2026-03-28 | standart/C (#69 ile çakışma riski!) |
-| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ (eski yazı genişletme) | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
+| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
 
-> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. İnceleyen kişinin dikkatine.
+> **Notlar:** #88 ile #98 aynı konuyu (WCET analizi) işliyor; inceleyen kişinin
+> birini reddetmesi gerekebilir. #51 ile yayındaki MISRA C:2025 yazısı (#69) örtüşüyor.
 
 ## Seçildi / Devam Eden
 
-- **Bandpass Sampling: 1 GHz Sinyali 50 MHz Saatle Örneklemek** —
-  dal: `post/2026-05-21-bandpass-sampling`,
-  dosya: `_posts/2026-05-21-bandpass-sampling.md`,
-  durum: PR açılacak (bu çalıştırma) — alan: RF/DSP.
+- **Priority Inversion ve Mars Pathfinder — FreeRTOS'ta Yeniden Üretim** —
+  dal: `post/2026-06-08-priority-inversion-mars-pathfinder`,
+  dosya: `_posts/2026-06-08-priority-inversion-mars-pathfinder.md`,
+  durum: PR açıldı (bu çalıştırma) — alan: RTOS/gerçek-zamanlı senkronizasyon.
 
 ## Reddedildi (bu çalıştırma)
 
-- _(bu çalıştırmada konu reddedilmedi; bandpass sampling havuzdan seçildi.)_
+- _(reddetme yok; havuzdan + Faz 2 üretiminden konu seçildi)_
 
 ## Fikir Havuzu (aday konular — gelecek çalıştırma için)
 
-Aşağıdaki adaylar, mevcut yazılar + açık PR'larla çakışmıyor ve Bölüm 6 kriterlerini
-geçici olarak karşılıyor. Faz 2'de tekrar değerlendirilmesi gerekir.
-
 ### Yüksek öncelikli (kalıcı değer + Türkçe boşluk)
 
-- [ ] **ARM Cortex-A reset vektöründen `main()`'e: gerçekten ne oluyor?** —
-      alan: gömülü/SoC — Renode yazısının doğal devamı, somut deney imkânı
-- [ ] **MC/DC kapsama: DO-178C DAL A'da neden modified condition/decision şart?** —
-      alan: sertifikasyon — gerçek karar tablosu örneği, decision/condition farkı
-- [ ] **CRC vs checksum: neden CRC-32 değil de CRC-32C / CRC-16-CCITT seçilir?** —
-      alan: yazılım zanaatı — polinom seçimi, hata tespit gücü, bit-hata analizi
-- [ ] **WCET analizi: statik analiz vs ölçüm tabanlı yaklaşımlar, cache etkileri** —
-      alan: gerçek zamanlı — somut örnek (örn. Cortex-R5 üzerinde basit görev)
-- [ ] **IQ örnekleme ve karmaşık sinyaller: gerçek SDR'ye giriş** —
-      alan: RF/SDR — neden negatif frekans, neden 2 kanal
-- [ ] **GIC (Generic Interrupt Controller): SGI/PPI/SPI farkları ve önceliklendirme** —
-      alan: ARM — kesme yönlendirme, multicore'da CPU affinity
-- [ ] **Cache coherency ve MESI: ARM'da CCI/CMN ne yapar, neden yazılım perde
-      (barrier) gerekir?** — alan: ARM — pratik race condition örneği
-- [ ] **Linker script anatomisi: ARM bare-metal için bir `.ld` dosyası satır satır** —
-      alan: gömülü — kendi linker script'i yazma rehberi
-- [ ] **Watchdog tasarım desenleri: tek vs çoklu görev watchdog, deadman switch,
-      windowed watchdog** — alan: güvenilirlik — gerçek tasarım kararları
-- [ ] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
-      alan: C/eşzamanlılık — derleyici çıktı analizi
-- [ ] **VOR'un çalışma prensibi: 30 Hz referans + değişken faz nasıl yön verir?** —
-      alan: navigasyon — faz farkı matematiği + sinyal şeması
-- [ ] **ILS anatomisi: localizer 90/150 Hz DDM ve glide slope** —
-      alan: navigasyon — modülasyon derinliği farkı + örnek hesap
-- [ ] **Kalman filtresi tuzakları: numerik stabilite, gözlemlenebilirlik, tuning** —
-      alan: navigasyon/füzyon — basit IMU örneği + Python kodu
-- [ ] **Sabit nokta (Q-format) aritmetik: Cortex-M0'da FPU yokken DSP nasıl yapılır?** —
-      alan: gömülü/DSP — Q15/Q31 örnekleri, overflow yönetimi
+- [ ] **ARM Cortex-A reset vektöründen `main()`'e** — alan: gömülü/SoC
+- [ ] **ARM Cortex-M Hard Fault analizi: stack frame, BFAR/CFSR yorumu, postmortem** — alan: gömülü/debug
+- [ ] **printf ve reentrancy: ISR'de printf, newlib `__malloc_lock`, async-signal-safety** — alan: gömülü/libc
+- [ ] **IEEE 754 NaN propagation ve signaling NaN: sertifikasyon zorlukları** — alan: sayısal
+- [ ] **ARINC 429 protokolü: 32-bit word formatı, label/SDI/SSM, neden hâlâ aviyonikte** — alan: aviyonik bus
+- [ ] **MIL-STD-1553: BC/RT/MT, dual-redundant bus, neden 40 yıl sonra hâlâ kullanılıyor** — alan: aviyonik bus
+- [ ] **Stack overflow tespiti Cortex-M üzerinde: canary, MPU, MSPLIM** — alan: gömülü/güvenlik
+- [ ] **DO-330 Araç Nitelendirme (Tool Qualification): TQL seviyeleri ve gerçek örnek** — alan: sertifikasyon
+- [ ] **ARP4754A — sistem geliştirme süreci, DAL allocation** — alan: sertifikasyon
+- [ ] **IQ örnekleme ve karmaşık sinyaller: negatif frekans, 2 kanal neden** — alan: RF/SDR
+- [ ] **Cache coherency MESI ARM CCI/CMN: yazılım bariyer neden gerekir** — alan: ARM (DMA #119 ile çakışma riski, dikkat)
+- [ ] **Single Event Upset, TMR, scrubbing — radyasyon dayanıklı yazılım** — alan: güvenilirlik
+- [ ] **Statik analiz neyi yakalar/kaçırır — Coverity/Polyspace somut C kodu üzerinden** — alan: araç
+- [ ] **Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain** — alan: yazılım zanaatı
 
 ### Orta öncelikli (kovaya alındı)
 
-- [ ] DO-330 araç nitelendirme (Tool Qualification) seviyeleri
-- [ ] ARP4754A — sistem geliştirme süreci
-- [ ] DO-326A / ED-202A havacılık siber güvenliği
 - [ ] FMEA pratikte: gerçek bir alt-sistem üzerinden adım adım
-- [ ] Fault Tree Analysis ile minimal cut set hesabı
 - [ ] FPU denormal performansı: Cortex-A vs x86 davranış farkı
-- [ ] Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain
-- [ ] Endianness: ağ baytı vs host baytı, ARM'ın iki modu, bitfield tuzakları
-- [ ] DMA yarış koşulları: ARM'da cache invalidation/clean stratejileri
-- [ ] Lockstep CPU mimarisi: TI Hercules / NXP MPC57xx örnekleri
+- [ ] Endianness: bitfield tuzakları, ARM iki modu
+- [ ] Lockstep CPU: TI Hercules / NXP MPC57xx
 - [ ] MPU vs MMU: hangisi ne zaman, FreeRTOS-MPU örneği
-- [ ] Statik analiz neyi yakalar / kaçırır: somut C kodu üzerinden Coverity/Polyspace
-- [ ] Radyasyona dayanıklı yazılım: SEU, TMR, scrubbing
-- [ ] ADS-B sinyal yapısı: PPM modülasyon, mesaj formatı
-- [ ] FIR vs IIR: faz cevabı, hesaplama maliyeti, stabilite
+- [ ] FIR vs IIR: faz cevabı, kararlılık
+- [ ] ADS-B sinyal yapısı: PPM modülasyon
+- [ ] GNSS spoofing ve RAIM
 
 ### Düşük öncelikli / sonraya bırak
 
-- [ ] ECSS uzay yazılım standartları ailesi (geniş, alt-konulara bölünmeli)
-- [ ] DO-254 donanım sertifikasyonu (yazarın uzmanlığı ağırlıklı yazılım tarafında)
-- [ ] İzlenebilirlik matrisi (klasik konu, derinlik çıkarmak zor)
+- [ ] ECSS uzay yazılım standartları ailesi (geniş)
+- [ ] DO-254 donanım sertifikasyonu
+- [ ] İzlenebilirlik matrisi (klasik, derinlik çıkarmak zor)
 
-## Notlar (bu çalıştırma — 2026-05-21)
+## Notlar (bu çalıştırma — 2026-06-08)
 
-- **Bandpass Sampling** seçildi (alan: RF/DSP). Önceki çalıştırmaların ardından
-  açılan PR'lar son üç alt-alanı (sertifikasyon #77, navigasyon #78, yazılım
-  zanaatı/CRC #79) işaretlemişti; bu yazı **bu üç alandan da** son yayınlanan 3
-  posttan da (Renode gömülü/SoC, kalibrasyon ×2) farklı bir alan getiriyor.
-- Yayın kapısı durumu: Bölüm 4 yalnızca "yayın PR ile olmalı" kuralı koyar; backlog
-  büyüklüğüne dair sert bir sınır yoktur. Açık 7 PR olmasına rağmen son yayınlanan
-  yazıdan (Renode, 2026-05-14) bu yana 7 gün geçti — `min_yayin_araligi_gun = 2`
-  şartı fazlasıyla sağlanmış durumda. Bu çalıştırmada yeni PR açıldı.
-- Bandpass sampling konusunun "neden Türkçe içerikte zor bulunuyor" yanıtı:
-  matematik (Vaughan 1991), datasheet okuma (analog input BW), saat phase noise
-  ve filtre tasarımı disiplinlerinin kesişiminde bulunuyor; Türkçe kaynaklar
-  genellikle yalnızca tek bir cepheden ele almış oluyor (genelde Lyons özet
-  çevirisi). Sentez ve somut sayısal örnek boşluğu büyük.
-- Açık PR'lar konusunda inceleme önceliği yorumu (gözlem): #50 ve #51 hâlâ uzun
-  süredir bekliyor; #50 eski yazıyı genişletiyor, #51 ise yayındaki MISRA C:2025
-  ile büyük olasılıkla çakışıyor. İnceleyen kişinin dikkatine.
+- **Seçim gerekçesi.** Priority inversion + Mars Pathfinder hiçbir yayında veya açık
+  20 PR'da yok. RTOS/gerçek-zamanlı senkronizasyon alanı son üç yayın (Coupling,
+  Kalman, Sistem Mühendisliği) ve son üç PR (DMA/cache #119, DO-326A #118, Q15 FIR
+  #114) ile çakışmıyor — alan rotasyonu uygulandı.
+- **"Türkçe'de neden zor bulunuyor".** Mars Pathfinder hikâyesi İngilizce kaynaklarda
+  detaylı (Reeves'in orijinal e-postası, Cornell CS614 arşivi) ama Türkçe sentez
+  yüzeysel — VxWorks `SEM_INVERSION_SAFE` flag adı, FreeRTOS karşılığı
+  (`xSemaphoreCreateMutex` vs `xSemaphoreCreateBinary`), PIP vs PCP worst-case
+  formülleri ve aviyonik sertifikasyon bağlantısı tek yerde birleştirilmiyor.
+- **Derinlik öğesi.** Üç katmanlı: (1) gerçek bug'ın aviyonik anatomisi (görev
+  isimleri, mutex flag'i, reset mekanizması), (2) FreeRTOS'ta reproduce kodu
+  ölçülebilir gecikme çıktısıyla (940 ms vs 150 ms), (3) PIP/PCP worst-case
+  blocking matematiksel karşılaştırması (`min(n,m)·C_max` vs `C_max`).
+- **Yayın kapısı.** Son yayından (Coupling, 2026-06-04) bu yana 4 gün geçti;
+  `min_yayin_araligi_gun = 2` rahatlıkla sağlandı. Açık 20 PR var ama Bölüm 4
+  backlog sınırı koymuyor — yayın akışı her durumda PR. Insan inceleyecek.
+- **Gizlilik.** Tüm bilgiler kamu kaynaklı: NASA/JPL yayını (Reeves), Wind River
+  açık dokümantasyonu, FreeRTOS açık dokümantasyon, 1990 IEEE makalesi. Yazarın
+  saha deneyimine atıf yok.


### PR DESCRIPTION
## Yeni yazı: Priority Inversion ve Mars Pathfinder — FreeRTOS'ta Yeniden Üretim

### Seçilen konu ve neden seçildi

**Konu:** Mars Pathfinder'ın 1997'deki priority inversion bug'ı, FreeRTOS'ta somut yeniden üretimi, Priority Inheritance vs Priority Ceiling protokollerinin worst-case bloklama analizi.

**Alan:** RTOS / gerçek zamanlı senkronizasyon.

**Neden bu konu:**
- Yayınlanan 22 yazıdan ve açık 20 PR'ın hiçbirinden anlam ya da başlık olarak çakışma yok (en yakın komşular: `volatile`/atomic #100 farklı katman, GIC #101 kesme katmanı, watchdog #89 hata tepkisi tarafı).
- Son üç yayın (Coupling 06-04, Kalman 06-02, Sistem Mühendisliği 05-26) hep yazılım-tasarım / matematik tarafındaydı; RTOS/gerçek-zamanlı eksenine sağlıklı bir rotasyon.
- Aviyonik gerçek bir hata vakası → DO-178C DAL A sertifikasyon kararlarına doğrudan bağlanıyor.

### Hangi derinlik öğesini taşıyor (Bölüm 7)

**Üç katmanlı somut derinlik:**

1. **Gerçek bug'ın aviyonik anatomisi.** Görev isimleri (`bc_sched`, `bc_dist`, ASI/MET), VxWorks `SEM_INVERSION_SAFE` flag'inin tam adı, deadline ihlali kaynaklı reset mekanizması (watchdog değil — zamanlayıcı kontrolünün kendisi).
2. **FreeRTOS yeniden üretim kodu.** `xSemaphoreCreateBinary()` ile patolojiyi, tek satır değiştirip `xSemaphoreCreateMutex()` ile düzeltmeyi yan yana, ölçülebilir konsol çıktısıyla — H görevinin bloklanma süresi **940 ms → 150 ms**.
3. **Worst-case bloklama matematiği.** PIP: `min(n,m)·C_max`. PCP: `C_max`. 3 görev × 4 mutex'lik somut tabloyla 95 ms vs 40 ms karşılaştırması, schedulability analiziyle bağ.

### "Bu konu Türkçe'de neden zor bulunuyor?" (Bölüm 8)

Bug İngilizce kaynaklarda detaylı (Reeves'in orijinal e-postası, Cornell CS614 arşivi, IEEE Sha-Rajkumar-Lehoczky 1990 makalesi) ama Türkçe tarafında yüzeysel — "öncelik tersine dönmesi var" diye geçilip kapanıyor. Bu yazı dört dağınık disiplini (Pathfinder vakası + VxWorks mutex semantiği + FreeRTOS API farkı + PIP/PCP formel sınırları + DO-178C sertifikasyon bağı) ilk kez **tek yerde** sentezliyor.

### Kullanılan kaynaklar

- Glenn E. Reeves, *What really happened on Mars Rover Pathfinder*, Cornell CS614 arşivi
- Reeves'in 1997 orijinal e-postası (CCSU mirror)
- Wind River, VxWorks `semMLib` referansı (`SEM_INVERSION_SAFE`)
- Sha, Rajkumar, Lehoczky, *Priority Inheritance Protocols*, IEEE TC, 1990
- FreeRTOS Kernel Documentation — Mutexes, Priority Inheritance
- Liu, *Real-Time Systems*, Prentice Hall, 2000, Bölüm 8
- POSIX 1003.1-2017, `pthread_mutexattr_setprotocol`

### Öz-eleştiri özeti (Bölüm 6, 13)

- ✅ Altı seçim kriteri sağlanıyor.
- ✅ Konu hiçbir yazıyla başlık veya anlam olarak çakışmıyor.
- ✅ Yazı somut bir derinlik öğesi taşıyor (üç katmanlı).
- ✅ Tüm olgusal iddialar doğrulandı (tarih: 4 Temmuz 1997, flag adı, görev isimleri).
- ✅ Kaynaklar gerçek ve erişilebilir.
- ✅ Hiçbir gizli/proje-spesifik bilgi yok — yalnızca kamuya açık standart ve literatür.
- ✅ Ön bilgi bloğu mevcut yazıların şemasıyla aynı (YAML doğrulandı).
- ✅ Türkçe + İngilizce alt-başlık; ton "sahadan", birinci tekil şahıs.
- ✅ Anti-pattern yok; derinlik gerçek.
- ✅ Dosya adı `2026-06-08-priority-inversion-mars-pathfinder.md`; dal adı `post/2026-06-08-priority-inversion-mars-pathfinder`.
- ✅ `master`'a hiçbir şey push edilmedi; teslim yalnızca PR.
- ✅ `agent/topics.md` defteri güncellendi (açık PR listesi senkronlandı, fikir havuzu yenilendi).

### Notlar

- Background image olarak `/img/posts/2.webp` seçildi — yayında olan yazılarda henüz kullanılmamış jenerik bir kapak. İstenirse konu-özel bir kapak (`priority-inversion-cover.webp`) sonradan eklenebilir.
- Aritmetik (940 ms ve 150 ms bloklanma süreleri) Faz 6 sırasında yeniden hesaplanıp tutarlılaştırıldı.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
