### PR TITLE
Site tasarımını iyileştir: öne çıkan yazı kartı, okuma ilerleme çubuğu ve mikro etkileşimler

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -9,16 +9,16 @@
     <div class="collapse navbar-collapse" id="navbarResponsive">
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <a class="nav-link" href="{{"/" | relative_url }}">Ana sayfa</a>
+          <a class="nav-link{% if page.url == '/' or page.url == '/index.html' %} active{% endif %}" {% if page.url == '/' or page.url == '/index.html' %}aria-current="page"{% endif %} href="{{"/" | relative_url }}">Ana sayfa</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{"/about" | relative_url }}">Hakkımda</a>
+          <a class="nav-link{% if page.url == '/about/' or page.url == '/hakkimda/' %} active{% endif %}" {% if page.url == '/about/' or page.url == '/hakkimda/' %}aria-current="page"{% endif %} href="{{"/about" | relative_url }}">Hakkımda</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{ "/posts" | relative_url }}">Yazılar</a>
+          <a class="nav-link{% if page.url contains '/posts' %} active{% endif %}" {% if page.url contains '/posts' %}aria-current="page"{% endif %} href="{{ "/posts" | relative_url }}">Yazılar</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{"/contact" | relative_url }}">İletişim</a>
+          <a class="nav-link{% if page.url == '/contact.html' or page.url == '/contact/' %} active{% endif %}" {% if page.url == '/contact.html' or page.url == '/contact/' %}aria-current="page"{% endif %} href="{{"/contact" | relative_url }}">İletişim</a>
         </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownProjects" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -34,18 +34,21 @@ layout: default
           {% for post in site.posts limit : 5 %}
           {% assign card_image = post.background | default: '/img/posts/1.webp' %}
           {% assign card_image_sm = card_image | replace: '/img/posts/', '/img/posts/sm/' %}
-          <article class="post-card">
+          <article class="post-card{% if forloop.first %} post-card--featured{% endif %}">
             <a class="post-card__media" href="{{ post.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
               {% if card_image contains '/img/posts/' %}
               <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}"
                    srcset="{{ card_image_sm | prepend: site.baseurl | replace: '//', '/' }} 768w, {{ card_image | prepend: site.baseurl | replace: '//', '/' }} 1600w"
-                   sizes="(max-width: 640px) 100vw, 220px"
+                   sizes="{% if forloop.first %}(max-width: 991px) 100vw, 760px{% else %}(max-width: 640px) 100vw, 220px{% endif %}"
                    alt="" loading="lazy" width="1600" height="1067" decoding="async">
               {% else %}
               <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}" alt="" loading="lazy" width="1600" height="1067" decoding="async">
               {% endif %}
             </a>
             <div class="post-card__body">
+              {% if forloop.first %}
+              <span class="post-card__badge">Son yazı</span>
+              {% endif %}
               <h2 class="post-card__title">
                 <a href="{{ post.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ post.title }}</a>
               </h2>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,9 @@
 layout: default
 ---
 
+<!-- Reading progress (filled by assets/scripts.js) -->
+<div class="reading-progress" aria-hidden="true"><div class="reading-progress__bar"></div></div>
+
 <!-- Page Header -->
 {% if page.background %}
 <header class="masthead" style="background-image: url('{{ page.background | prepend: site.baseurl | replace: '//', '/' }}')">

--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -10,6 +10,8 @@
   --color-accent: #0085A1;
   --color-accent-hover: #00a3c4;
   --color-accent-contrast: #ffffff;
+  --color-accent-soft: rgba(0, 133, 161, 0.08);
+  --color-accent-soft-border: rgba(0, 133, 161, 0.25);
 
   // Surfaces
   --color-bg: #ffffff;
@@ -86,6 +88,8 @@
 
   --color-accent: #4ec9d6;
   --color-accent-hover: #7bdbe6;
+  --color-accent-soft: rgba(78, 201, 214, 0.1);
+  --color-accent-soft-border: rgba(78, 201, 214, 0.3);
 
   --color-overlay-dark: #0b0d12;
   --color-overlay-darker: #060709;
@@ -221,6 +225,28 @@ body > .container,
     text-transform: uppercase;
   }
 
+  // Current-page indicator: short accent rule under the active link
+  .navbar-nav > li.nav-item > a.active {
+    position: relative;
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 1rem;
+      right: 1rem;
+      bottom: 0.35em;
+      height: 2px;
+      background-color: var(--color-accent);
+      border-radius: 2px;
+    }
+
+    @media only screen and (max-width: 991.98px) {
+      color: var(--color-accent);
+
+      &::after { display: none; }
+    }
+  }
+
   @media only screen and (min-width: 992px) {
     &.is-fixed {
       background-color: var(--color-glass-bg);
@@ -296,6 +322,29 @@ body > .container,
       color: var(--color-accent);
       border-color: var(--color-accent);
     }
+  }
+}
+
+// =============================================================================
+// Reading progress bar (post pages)
+// =============================================================================
+.reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 1100; // above Bootstrap's fixed navbar (1030)
+  pointer-events: none;
+  background: transparent;
+
+  &__bar {
+    height: 100%;
+    width: 100%;
+    transform: scaleX(0);
+    transform-origin: left;
+    background: linear-gradient(90deg, var(--color-accent), var(--color-accent-hover));
+    will-change: transform;
   }
 }
 
@@ -485,9 +534,79 @@ header.masthead {
   }
 }
 
+// Featured variant — latest post gets a full-width editorial card with the
+// image on top and a larger title.
+.post-card--featured {
+  grid-template-columns: 1fr;
+  gap: 0;
+
+  .post-card__media img {
+    min-height: 200px;
+    max-height: 340px;
+    aspect-ratio: 21 / 9;
+  }
+
+  .post-card__body {
+    padding: 1.5rem 1.75rem 1.6rem;
+    align-items: flex-start;
+  }
+
+  .post-card__title {
+    font-size: clamp(1.5rem, 3vw, 1.9rem);
+  }
+
+  .post-card__subtitle {
+    font-size: 1.08rem;
+  }
+
+  @media (max-width: 640px) {
+    .post-card__media img { aspect-ratio: auto; }
+    .post-card__body { padding: 1.25rem 1.4rem 1.5rem; }
+  }
+}
+
+.post-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  align-self: flex-start;
+  margin-bottom: 0.7rem;
+  padding: 0.22rem 0.65rem;
+  font-family: var(--font-sans);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  background-color: var(--color-accent-soft);
+  border: 1px solid var(--color-accent-soft-border);
+  border-radius: 999px;
+}
+
 // Hide the legacy <hr> separators when using the new card layout
 .post-list + .clearfix hr,
 .post-card + hr { display: none; }
+
+// =============================================================================
+// Scroll reveal — cards fade/rise in as they enter the viewport.
+// The hidden state only applies once JS adds `reveal-ready` to <html>, so
+// content stays visible without JS. Uses an animation (not a transition) so
+// the card's own hover transform keeps working afterwards.
+// =============================================================================
+@keyframes reveal-rise {
+  from { opacity: 0; transform: translateY(22px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+html.reveal-ready {
+  .post-card:not(.is-revealed) {
+    opacity: 0;
+  }
+
+  .post-card.is-revealed {
+    animation: reveal-rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+  }
+}
 
 // =============================================================================
 // Buttons (themed)
@@ -521,6 +640,14 @@ header.masthead {
   margin-top: 2rem;
 
   &--end { justify-content: flex-end; }
+}
+
+.pager-status {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-subtle);
+  letter-spacing: 0.04em;
 }
 
 // =============================================================================

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -238,6 +238,65 @@
     document.addEventListener('click', closeAllDropdowns);
   }
 
+  // ---------------------------------------------------------------------------
+  // Reading progress bar (post pages): fills as the reader scrolls the page
+  // ---------------------------------------------------------------------------
+  function initReadingProgress() {
+    var bar = document.querySelector('.reading-progress__bar');
+    if (!bar) return;
+
+    var ticking = false;
+    function update() {
+      ticking = false;
+      var doc = document.documentElement;
+      var max = doc.scrollHeight - window.innerHeight;
+      var progress = max > 0 ? window.scrollY / max : 0;
+      bar.style.transform = 'scaleX(' + Math.min(Math.max(progress, 0), 1) + ')';
+    }
+
+    window.addEventListener('scroll', function () {
+      if (!ticking) {
+        ticking = true;
+        window.requestAnimationFrame(update);
+      }
+    }, { passive: true });
+    window.addEventListener('resize', update);
+    // Re-sync when lazy-loaded content (e.g. Disqus) changes the page height
+    if ('ResizeObserver' in window) {
+      new ResizeObserver(function () { update(); }).observe(document.body);
+    }
+    update();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scroll reveal: post cards rise in as they enter the viewport.
+  // Without JS (or with reduced motion) the `reveal-ready` class is never
+  // added, so cards stay fully visible.
+  // ---------------------------------------------------------------------------
+  function initScrollReveal() {
+    if (!('IntersectionObserver' in window)) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    var items = document.querySelectorAll('.post-card');
+    if (!items.length) return;
+
+    document.documentElement.classList.add('reveal-ready');
+
+    var observer = new IntersectionObserver(function (entries) {
+      var delay = 0;
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        var el = entry.target;
+        observer.unobserve(el);
+        // Stagger items revealed in the same batch (e.g. initial viewport)
+        setTimeout(function () { el.classList.add('is-revealed'); }, delay);
+        delay += 70;
+      });
+    }, { rootMargin: '0px 0px -6% 0px', threshold: 0.05 });
+
+    items.forEach(function (el) { observer.observe(el); });
+  }
+
   function ready(fn) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', fn);
@@ -307,5 +366,7 @@
     initNavbarToggle();
     initNavbarDropdowns();
     initBayramSplash();
+    initReadingProgress();
+    initScrollReveal();
   });
 })();

--- a/posts/index.html
+++ b/posts/index.html
@@ -8,9 +8,17 @@ lang: tr
 <div class="post-list">
   {% for post in paginator.posts %}
   {% assign card_image = post.background | default: '/img/posts/1.webp' %}
+  {% assign card_image_sm = card_image | replace: '/img/posts/', '/img/posts/sm/' %}
   <article class="post-card">
     <a class="post-card__media" href="{{ post.url | remove: '.html' | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ post.title | escape }}">
-      <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}" alt="" loading="lazy">
+      {% if card_image contains '/img/posts/' %}
+      <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}"
+           srcset="{{ card_image_sm | prepend: site.baseurl | replace: '//', '/' }} 768w, {{ card_image | prepend: site.baseurl | replace: '//', '/' }} 1600w"
+           sizes="(max-width: 640px) 100vw, 220px"
+           alt="" loading="lazy" width="1600" height="1067" decoding="async">
+      {% else %}
+      <img src="{{ card_image | prepend: site.baseurl | replace: '//', '/' }}" alt="" loading="lazy" width="1600" height="1067" decoding="async">
+      {% endif %}
     </a>
     <div class="post-card__body">
       <h2 class="post-card__title">
@@ -40,9 +48,11 @@ lang: tr
   <a class="btn btn-primary" href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Yeni yazılar</a>
   {% else %}<span></span>{% endif %}
 
+  <span class="pager-status">Sayfa {{ paginator.page }} / {{ paginator.total_pages }}</span>
+
   {% if paginator.next_page %}
   <a class="btn btn-primary" href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Eski yazılar &rarr;</a>
-  {% endif %}
+  {% else %}<span></span>{% endif %}
 </div>
 
 {% endif %}


### PR DESCRIPTION
## Özet

Mevcut tasarım sistemini (token'lar, karanlık tema, kartlar) bozmadan beş görünür iyileştirme:

- **Öne çıkan yazı kartı (ana sayfa):** En yeni yazı, üstte geniş görselli, "Son yazı" rozetli ve büyük başlıklı tam genişlik bir kartla gösteriliyor; kalan 4 yazı mevcut kart düzeninde.
- **Okuma ilerleme çubuğu (yazı sayfaları):** Sayfanın en üstünde 3px'lik accent gradyanlı çubuk, kaydırma ilerledikçe doluyor. Tembel yüklenen içerik (Disqus) sayfa yüksekliğini değiştirdiğinde `ResizeObserver` ile yeniden senkronize oluyor.
- **Scroll-reveal animasyonu:** Yazı kartları görünüm alanına girerken hafif yükselme + solma animasyonuyla beliriyor. JS yokken veya `prefers-reduced-motion` açıkken tamamen devre dışı (kartlar her zaman görünür); animasyon `transition` yerine `animation` kullandığı için kartların hover kaldırma efekti bozulmuyor.
- **Aktif sayfa göstergesi (navbar):** Geçerli sayfanın menü bağlantısı accent alt çizgiyle işaretleniyor, `aria-current="page"` ile birlikte. Mobilde alt çizgi yerine accent renk kullanılıyor.
- **Yazı arşivi cilası (/posts):** Kart görselleri ana sayfayla aynı responsive `srcset`/`sizes` özniteliklerini kullanıyor (768w sm varyantları); sayfalayıcıya "Sayfa X / Y" göstergesi eklendi.

Yeni renk token'ları (`--color-accent-soft`, `--color-accent-soft-border`) rozet için her iki temada da tanımlandı.

## Test

- `jekyll build` temiz geçiyor (ImageMagick ile sm küçük resimleri dahil).
- Headless Chromium (Playwright) ile yerel sunucu üzerinde doğrulandı:
  - Ana sayfa açık/koyu tema + mobil (390px) görünümde öne çıkan kart ve rozet doğru render ediliyor.
  - İlerleme çubuğu yazı ortasında `scaleX(0.38)`, 3px, gradyan, navbar'ın üstünde (z-index 1100).
  - Kaydırma sonrası tüm kartlar reveal oluyor; her sayfada tam olarak 1 aktif nav bağlantısı var.
  - Konsolda yeni JS hatası yok (yalnızca önceden var olan, çevrimdışı kaynaklı "Sentry is not defined").
- Canlı doğrulama: master'a merge sonrası GitHub Actions gh-pages'e dağıttığında karaman.dev üzerinde görünür olacak.

https://claude.ai/code/session_01UPpFc71YLAoTgepvuY4baQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPpFc71YLAoTgepvuY4baQ)_