### PR TITLE
Jitter SNR formülünün MathJax tarafından render edilememesini düzelt

### DIFF
--- a/_posts/2026-05-21-bandpass-sampling.md
+++ b/_posts/2026-05-21-bandpass-sampling.md
@@ -138,8 +138,10 @@ Bir tasarım kuralı olarak: **f_H < analog BW / 2** koşulu sağlanmadan o ADC 
 
 ADC analog bant genişliği yeterli olsa bile, yüksek IF'te sinyali sınırlandıran başka bir parametre ortaya çıkar: **clock jitter'ı**, yani aperture jitter. Tipik formülü şudur:
 
+<!-- Formüllerde }_{ kalıbından kaçının: kramdown kelime sınırına denk gelen
+     alt çizgi çiftini <em> olarak eşleştirip MathJax'ten önce TeX'i bozuyor. -->
 $$
-\text{SNR}_{\text{jitter}} = -20 \log_{10}(2\pi \cdot f_{\text{in}} \cdot \sigma_t)
+\mathrm{SNR_{jitter}} = -20 \log_{10}(2\pi \cdot f_{\text{in}} \cdot \sigma_t)
 $$
 
 Burada f_in **analog giriş** frekansıdır (örnekleme hızı değil!) ve σ_t clock kaynağının RMS jitter değeridir. Formülde gizli olan korkutucu gerçek şudur: SNR, sinyal frekansıyla doğrudan azalır. Baseband'de problem olmayan jitter, 1 GHz IF'te uygulamayı imkânsız hale getirebilir.


### PR DESCRIPTION
Bandpass sampling yazısındaki jitter SNR formülü sayfada render edilmeyip ham metin olarak kalıyordu.

## Kök neden

jekyll-spaceship, `$$` sınırlayıcılarını kramdown'dan kaçırıyor (istemci tarafında MathJax işlesin diye) ama blok **içeriği** kramdown'ın normal Markdown işlemesine açık kalıyor. Formüldeki `}_{\text{jitter}}` ve `\log_{10}` alt çizgileri kelime sınırına denk geldiği için kramdown ikisini vurgu çifti olarak eşleştirip araya `<em>` etiketi sokuyordu:

```html
<p>$$ \text{SNR}<em>{\text{jitter}} = -20 \log</em>{10}(...) $$</p>
```

MathJax, içinde HTML etiketi olan bloğu TeX olarak ayrıştıramadığından formül ham metin kalıyordu. Yazıdaki diğer iki formül, alt çizgileri harf aralarında olduğu için (ör. `f_H` — kramdown kelime içi `_`'yi vurgu saymaz) etkilenmemişti.

## Düzeltme

Formül, alt çizgiden önce daima harf gelecek şekilde `\mathrm{SNR_{jitter}}` olarak yeniden yazıldı — harf bitişiğindeki `_` kramdown'da vurgu açamaz, render edilen görünüm ise birebir aynı. Markdown kaynağına, gelecekteki formüllerde `}_{` kalıbından kaçınılması gerektiğini belirten kısa bir not eklendi.

## Doğrulama

- Site genelindeki üretilmiş tüm `$$` blokları tarandı; `<em>`/`<strong>` ile bozulan **tek** formül buydu.
- `jekyll build` sonrası üç formülün de temiz TeX olarak çıktığı, MathJax config ve script'inin sayfaya enjekte edildiği doğrulandı.

https://claude.ai/code/session_01FCGjTazjxL21zvVxuJdPuD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCGjTazjxL21zvVxuJdPuD)_