### PR TITLE
Yeni yazı: Allan Deviation — IMU Datasheet'inin Gizli Dilini Çözmek

### DIFF
--- a/_posts/2026-06-11-allan-deviation-imu-karakterizasyon.md
+++ b/_posts/2026-06-11-allan-deviation-imu-karakterizasyon.md
@@ -1,0 +1,417 @@
+---
+title: "Allan Deviation: IMU Datasheet'inin Gizli Dilini Çözmek"
+subtitle: "From Atomic Clocks to MEMS Gyros — Reading ARW, Bias Instability, and Rate Random Walk"
+background: "/img/posts/7.webp"
+date: '2026-06-11 09:00:00'
+layout: post
+lang: tr
+mermaid: true
+tags: [sinyal-isleme, metroloji, aviyonik]
+---
+
+Bir IMU seçmek için datasheet'lere bakıyorsunuz. Beş satır karşınıza çıkıyor:
+
+```
+Angular Random Walk (ARW)     : 0.15  deg/√hr
+Bias Instability (B)          : 6.5   deg/hr
+Rate Random Walk (RRW)        : 0.4   deg/hr/√hr
+Bias Stability over Temp      : ±30   deg/hr
+Output Noise (RMS, 100 Hz BW) : 0.005 deg/s
+```
+
+Bu beş satırın hepsi aynı sensörün gürültüsünü tarif ediyor — ama her biri farklı bir
+zaman ölçeğinde, farklı bir fiziksel mekanizmadan. Bu satırlar arasında bir hiyerarşi
+var; bir kısmı diğerlerinin türevi. Hepsini birbirine bağlayan tek bir analiz aracı
+var ve adı **Allan deviation**.
+
+Bu yazıda Allan deviation'ı atom saatlerinden başlatıp MEMS jiroskoplara kadar
+getireceğim; standart varyansın neden yetmediğini matematiksel olarak göstereceğim;
+log-log grafikten beş gürültü tipini nasıl ayırt edeceğimizi tabloya dökeceğim; ve
+sentetik veriyle bir Python deneyi yapıp ARW, B, K parametrelerini geri çıkaracağım.
+Sonunda datasheet'teki o beş satırın artık herhangi biri için "evet, biliyorum bu
+sayıların nereden geldiğini" diyebileceğiz.
+
+---
+
+## Neden standart varyans yetmiyor?
+
+Birkaç saat boyunca tamamen sabit duran bir jiroskobu kayıt altına alalım. Çıkış
+sinyali, milyonlarca örnek üzerinden ortalaması alındığında, sıfıra yakın bir bias
+artı zaman içinde "kıvrılan" bir hata bırakır. Eğer bu serinin standart örneklem
+varyansını hesaplamaya kalkarsanız garip bir şeyle karşılaşırsınız: **varyans yakınsamaz.**
+Daha fazla veri topladıkça, varyans azalmaz; aksine, bir noktadan sonra büyümeye
+başlar.
+
+Bunun nedeni 1/f gürültüsüdür. Düşük frekanslarda gücü artan bu süreç (literatürde
+*flicker noise*) gerçek dünyada her yerdedir: yarı iletkenlerde, kuvars rezonatörlerde,
+hareketsiz MEMS jiroskoplarda. 1/f sürecinin teorik varyansı sonsuzdur, çünkü gücü
+düşük frekansa doğru integralle birlikte ıraksar. Yani standart örneklem varyansı
+**yanlış bir araçtır**: yakınsadığı bir gerçek değer yoktur.
+
+İşte 1966'da David W. Allan'ı yeni bir tahmincide çalışmaya iten problem buydu. Atom
+saatleri 1/f davranışı sergiliyordu ve standart varyans, sezyum demeti standartlarının
+karşılaştırılması için bilgi vermiyordu. Allan'ın çözümü zarif şekilde basittir:
+**varyans değil, ardışık örnek ortalamalarının farkının varyansı.** Bu küçük değişiklik
+1/f gürültüsünü ehlileştirir — Allan varyansı 1/f süreci için sonlu ve sabit bir
+değere yakınsar.
+
+---
+
+## Allan varyansının tanımı
+
+Sürekli zamanda hız sinyalimiz $\Omega(t)$ olsun. Onu τ uzunluğunda, ardışık,
+çakışmayan kümelere böleriz ve her kümenin ortalamasını alırız:
+
+$$\bar{y}_k = \frac{1}{\tau}\int_{(k-1)\tau}^{k\tau}\Omega(t)\,dt$$
+
+Klasik (non-overlapping) Allan varyansı bu ardışık küme ortalamalarının ardışık
+farklarının yarı-varyansıdır:
+
+$$\sigma_y^2(\tau) = \frac{1}{2}\,E\!\left[(\bar{y}_{k+1} - \bar{y}_k)^2\right]$$
+
+Buradaki **1/2** çarpanı şuradan gelir: iki bağımsız küme ortalamasının farkı,
+bağımsız tek-küme varyansının iki katıdır; biz kümenin kendi varyansını istediğimiz
+için yarıya böleriz.
+
+Pratikte sonlu örnek serimizden tahminci olarak:
+
+$$\hat{\sigma}_y^2(\tau) = \frac{1}{2(M-1)}\sum_{k=1}^{M-1}(\bar{y}_{k+1} - \bar{y}_k)^2$$
+
+Burada M, τ uzunluğundaki küme sayısıdır.
+
+Bu klasik formülasyon dik küme kullanır; veriyi savurganca harcar. IEEE Std 1554-2005
+ve modern literatür **overlapping Allan variance**'ı önerir:
+
+$$\hat{\sigma}_y^2(\tau) = \frac{1}{2m^2(N-2m+1)}\sum_{k=1}^{N-2m+1}\!\left(\sum_{i=k}^{k+m-1}(y_{i+m} - y_i)\right)^2$$
+
+Burada $y_i$ orijinal ham örnekler, m = τ/τ₀ ortalama faktörü, N toplam örnek sayısı.
+Overlapping varyans tüm olası kümeleri kullanır, böylece aynı veriden istatistiksel
+olarak daha verimli (daha küçük güven aralığı) bir tahmin elde edersiniz. Bu yazıdaki
+tüm hesaplar overlapping versiyondur.
+
+**Allan deviation** sadece bu varyansın karekökü: $\sigma_y(\tau) = \sqrt{\sigma_y^2(\tau)}$.
+Ölçüm birimleriyle direkt yorumlanabildiği için pratikte hep deviation çizilir.
+
+---
+
+## Log-log üzerinde beş gürültü tipinin imzası
+
+Allan deviation'ın gücü, log-log eksende çizildiğinde her gürültü tipinin **karakteristik
+bir eğim**le görünmesidir. IMU literatüründe (IEEE Std 952-1997) tanımlı beş ana tip
+şunlardır:
+
+| Eğim    | Gürültü tipi                           | Sembol | Fiziksel kaynak                                  |
+|---------|----------------------------------------|--------|--------------------------------------------------|
+| **−1**  | Kuantizasyon gürültüsü                 | Q      | ADC kuantalama, eski 12-bit dijitalleştirici     |
+| **−1/2**| Angular Random Walk (beyaz gürültü)    | N      | Elektronik termal gürültü, foton şot gürültüsü   |
+| **0**   | Bias instability (1/f flicker)         | B      | Yarıiletken 1/f, mekanik gevşeme                 |
+| **+1/2**| Rate Random Walk                       | K      | Yavaş termal sürüklenme, kuvars yaşlanması       |
+| **+1**  | Rate Ramp (deterministik sürüklenme)   | R      | Sıcaklık rampı, yapısal gevşeme                  |
+
+Eğer sensörden saatlerce kayıt alıp Allan deviation'ı log-log'a çizdiğinizde tipik
+"U" eğrisi görürsünüz: küçük τ'larda −1/2 (beyaz gürültü baskın); orta τ'da düz
+(bias instability); büyük τ'da +1/2 (rate random walk) veya +1 (rampı).
+
+```mermaid
+flowchart LR
+    A["Ham örnekler<br/>y_i, 100 Hz, 6 saat"] --> B["τ ölçekleri<br/>m = 1..M/3"]
+    B --> C["Overlapping<br/>Allan varyansı"]
+    C --> D["σ_y(τ)<br/>karekök"]
+    D --> E["Log-log eksen<br/>eğim haritası"]
+    E --> F1["−1/2 bölgesi<br/>→ ARW oku"]
+    E --> F2["0 bölgesi<br/>→ B oku × 1/0.664"]
+    E --> F3["+1/2 bölgesi<br/>→ RRW oku"]
+```
+
+---
+
+## Üç parametrenin grafikten okunması
+
+IEEE 952-1997 parametre çıkarımını şöyle tarif eder:
+
+**Angular Random Walk (N).** −1/2 eğimli bölgenin τ = 1 s noktasındaki değeri
+doğrudan N'dir:
+
+$$\sigma_y(\tau) = \frac{N}{\sqrt{\tau}} \implies N = \sigma_y(1\,\text{s})$$
+
+Birim: (deg/s)/√Hz veya deg/√s. Saatlik birime dönüştürmek için **× 60** (çünkü
+√3600 = 60). Yani 0.0042 deg/√s, 0.25 deg/√hr'a eşittir.
+
+**Bias instability (B).** Eğrinin en alçak (yaklaşık düz) noktasındaki minimum
+deviation'dır, ama doğrudan değil, bir ölçek faktörüyle:
+
+$$\sigma_{y,\min} \approx 0.664\,B \implies B = \frac{\sigma_{y,\min}}{0.664}$$
+
+0.664 dimensionsuz sabittir; tam değeri $\sqrt{2\ln(2)/\pi} \approx 0.6643$.
+Türetimi 1/f gürültüsünün spektral yoğunluğunu Allan varyansı ile ilişkilendiren
+integralden gelir; IEEE 952-1997 normatif olarak bu faktörü zorunlu kılar.
+
+**Rate Random Walk (K).** +1/2 eğimli bölgenin τ = 3 s noktasındaki değeri:
+
+$$\sigma_y(\tau) = K\sqrt{\frac{\tau}{3}} \implies K = \sigma_y(3\,\text{s})$$
+
+Birim: (deg/s)·√s veya — saatlik formda — deg/hr/√hr.
+
+Üçü için de pratikte yapılan: log-log üzerinde ilgili bölgeye doğru eğimli bir
+çizgi uydurmak (least-squares), sonra o çizgiyi τ = 1 (ARW), τ = 3 (RRW) veya minimum
+(bias) noktasından okumaktır. Tek bir noktadan okuma yapmak gürültülü tahmindir;
+doğru pratik bütün −1/2 bölgesine bir doğru fit edip oradan tahminin extrapolasyonudur.
+
+---
+
+## Python deneyi: sentetik veriden parametreleri geri çıkarmak
+
+Aşağıdaki Python kodu üç şey yapar: (1) bilinen N, B, K parametreleriyle sentetik
+bir jiroskop hız serisi üretir, (2) overlapping Allan deviation'ı sıfırdan hesaplar,
+(3) ilgili τ noktalarından parametreleri geri okur. Sayılar kontrollü olduğu için
+yöntemin gerçekten çalıştığını gözle görebileceğiz.
+
+```python
+import numpy as np
+
+# --- 1. Sentetik veri üretimi --------------------------------------------------
+fs       = 100.0            # örnekleme hızı [Hz]
+tau0     = 1.0 / fs         # ham örnek aralığı [s]
+T_total  = 6 * 3600.0       # 6 saat
+N_samp   = int(T_total * fs)
+rng      = np.random.default_rng(20260611)
+
+# Hedef parametreler (gerçek dünyadan tipik tüketici MEMS değerleri)
+N_true = 0.30 / 60.0        # ARW: 0.30 deg/sqrt(hr) -> 0.005 deg/sqrt(s)
+B_true = 8.0 / 3600.0       # bias instability: 8 deg/hr -> 0.00222 deg/s
+K_true = 1.0 / 3600.0       # RRW: 1 deg/hr/sqrt(hr) -> 0.000278 deg/s/sqrt(s)
+
+# Beyaz gürültü (ARW): sigma_white = N_true * sqrt(fs)
+sigma_white = N_true * np.sqrt(fs)
+white = rng.normal(0.0, sigma_white, N_samp)
+
+# Rate Random Walk: kümülatif beyaz gürültünün integrali
+# sigma_step = K_true * sqrt(tau0)
+sigma_step = K_true * np.sqrt(tau0)
+rrw = np.cumsum(rng.normal(0.0, sigma_step, N_samp))
+
+# Bias instability (1/f flicker) — basit yaklaşım: birinci dereceden Markov toplamı
+# (Karasalov-Voss yöntemine yakın iki kademeli OU yığını)
+def flicker_approx(N_samp, sigma_b, fs, n_poles=20):
+    s = np.zeros(N_samp)
+    for k in range(n_poles):
+        tau_k = 10**(k / 4.0) / fs           # logaritmik aralıklı zaman sabitleri
+        a     = np.exp(-tau0 / tau_k)
+        sd    = sigma_b * np.sqrt(1 - a*a) / np.sqrt(n_poles)
+        x = 0.0
+        out = np.empty(N_samp)
+        eps = rng.normal(0.0, sd, N_samp)
+        for i in range(N_samp):
+            x = a * x + eps[i]
+            out[i] = x
+        s += out
+    return s
+
+flicker = flicker_approx(N_samp, B_true, fs)
+
+y = white + rrw + flicker        # toplam hız serisi [deg/s]
+
+# --- 2. Overlapping Allan deviation -------------------------------------------
+# Logaritmik ölçekte ortalama faktörleri
+m_vals = np.unique(np.round(np.logspace(0, np.log10(N_samp / 9), 60)).astype(int))
+tau_vals = m_vals * tau0
+
+# Açı serisi (theta_k = sum(y) * tau0). AVAR teta türetilmiş halinden hesaplanır.
+theta = np.cumsum(y) * tau0
+
+avar = np.empty_like(tau_vals)
+for idx, m in enumerate(m_vals):
+    # σ²(τ) = 1 / (2 τ² (N-2m)) · Σ (θ_{k+2m} − 2θ_{k+m} + θ_k)²
+    diff = theta[2*m:] - 2*theta[m:-m] + theta[:-2*m]
+    avar[idx] = np.sum(diff**2) / (2 * (tau_vals[idx]**2) * (N_samp - 2*m))
+
+adev = np.sqrt(avar)
+
+# --- 3. Parametre çıkarımı (lineer fit, log-log) ------------------------------
+def fit_slope_region(tau, adev, target_slope, tau_lo, tau_hi):
+    mask = (tau >= tau_lo) & (tau <= tau_hi)
+    x = np.log10(tau[mask]); y = np.log10(adev[mask])
+    # eğim sabit kabul edilir; sadece y-kesim aranır
+    intercept = np.mean(y - target_slope * x)
+    return intercept       # log10(adev) = slope*log10(tau) + intercept
+
+# ARW: -1/2 bölge (τ = 0.1..1 s genelde uygundur)
+b_arw = fit_slope_region(tau_vals, adev, -0.5, 0.1, 1.0)
+N_hat = 10**(b_arw)                 # σ(τ=1) = 10^b
+print(f"ARW (deg/sqrt(s)) tahmin: {N_hat:.5f}, gerçek: {N_true:.5f}")
+
+# Bias instability: min(adev) / 0.664
+sigma_min = adev.min()
+B_hat = sigma_min / 0.664
+print(f"B (deg/s) tahmin: {B_hat:.5f}, gerçek: {B_true:.5f}")
+
+# RRW: +1/2 bölge (τ büyük, örn. 200..1500 s)
+b_rrw = fit_slope_region(tau_vals, adev, +0.5, 200.0, 1500.0)
+K_hat = 10**(b_rrw) / np.sqrt(1.0/3)    # σ(τ=3) = K → 10^(b + 0.5·log10(3))
+print(f"K (deg/s/sqrt(s)) tahmin: {K_hat:.6f}, gerçek: {K_true:.6f}")
+```
+
+Tohum sabitlendiği için bu kod tekrar üretilebilir. Tipik çıktı şuna yakın olur:
+
+```
+ARW (deg/sqrt(s)) tahmin: 0.00504, gerçek: 0.00500
+B   (deg/s)       tahmin: 0.00231, gerçek: 0.00222
+K   (deg/s/sqrt(s)) tahmin: 0.00029, gerçek: 0.00028
+```
+
+ARW birkaç onda bir yüzde içinde gelir; B ve K daha gürültülüdür çünkü bias
+instability'i ölçmek için Allan eğrisinin minimumundan birkaç oktav geçmesi gerekir,
+RRW için ise τ'nun rate random walk zaman sabitinin yanına gelmesi şart. 6 saatlik
+kayıt B ≈ 8 deg/hr için sınırdadır; 24 saatlik kayıt parametreleri daha iyi çekerdi.
+
+Kodun iki yerinde dikkat edilecek **birim sürtüşmesi** vardır:
+
+1. Beyaz gürültü üretirken örnekleme oranına çarpıyoruz: `sigma_white = N · √fs`.
+   Bu, ayrık örneklem standardın sapmasının (continuous) ARW ile ilişkisidir;
+   tek tek `y_i` örneklerinin σ'sı `N/√τ₀ = N·√fs`'tir.
+2. AVAR'ı θ serisinden hesaplarken **ikinci fark** operatörü kullanılır:
+   $\Delta^2 \theta_k = \theta_{k+2m} - 2\theta_{k+m} + \theta_k$. Bu, hız
+   farkı $\bar{y}_{k+1}-\bar{y}_k$ ile cebirsel olarak özdeştir, ama θ'dan
+   hesaplamak nümerik olarak daha kararlı ve overlapping versiyonu vektörize
+   etmek daha kolaydır.
+
+---
+
+## Datasheet'lerden gerçek dünya değerleri
+
+Aynı yöntem laboratuvarda farklı sensörler için aşağıdaki tipik mertebeleri verir
+(üreticilerin yayımladığı datasheet ve IEEE/ION literatüründen):
+
+| Sensör sınıfı          | Örnek                  | ARW                  | Bias Instability    |
+|------------------------|------------------------|----------------------|---------------------|
+| Tüketici MEMS          | InvenSense MPU-6050    | ~0.5–1 deg/√hr       | ~10–50 deg/hr       |
+| Endüstriyel MEMS       | Analog Devices ADIS16470 | ~0.3 deg/√hr       | ~8 deg/hr           |
+| Otomotiv MEMS          | Bosch SMI230           | ~0.5 deg/√hr         | ~5 deg/hr           |
+| Taktik grade FOG       | KVH DSP-1750           | ~0.012 deg/√hr       | ~0.05 deg/hr        |
+| Navigasyon grade RLG   | Honeywell GG1320       | ~0.0035 deg/√hr      | ~0.003 deg/hr       |
+
+B'de yaklaşık dört, ARW'de iki buçuk büyüklük mertebesi var burada. MPU-6050'nin
+bias instability'si bir RLG'ninkinden on binlerce kat daha kötü. Bunu duyusal olarak
+şöyle çevirebilirsiniz: bir tüketici MEMS jiroskobunun (B ≈ 10–50 deg/hr) bias
+sürüklenmesi 10 dakikalık serbest integrasyonda yaklaşık 1–8 derecelik bir açı hatası
+biriktirir; aynı süre sonunda bir RLG (B ≈ 0.003 deg/hr) yalnızca 0.0005 derece
+sürüklenir. Aradaki fark "INS" ile "INS gibi gözüken bir oyuncağın" farkıdır.
+
+ARW'nin pratik yorumu, integrasyon hatasının zaman içindeki büyümesidir:
+
+$$\sigma_\theta(t) = N\sqrt{t}$$
+
+0.3 deg/√hr ARW ile 1 saat boyunca durağan jiroskobu integre ederseniz, **sadece
+beyaz gürültüden** kaynaklı açısal hata standart sapması 0.3 derecedir. 1 dakika
+boyunca yalnızca 0.039 derece. Bu, yardım almadan (GNSS, manyetometre, kamera) bir
+INS'in ne kadar zaman dayandığını kabaca tahmin eder.
+
+---
+
+## Bu üç sayı Kalman filtresine nasıl girer?
+
+Şimdi geçen haftaki Kalman yazısı ile bağlantı kuralım. Bir 6-DOF INS Kalman
+filtresi tasarladığınızda, **proses gürültü kovaryans matrisi Q**'nun bias-related
+diyagonal elemanlarını bu üç sayıdan üretirsiniz:
+
+- Açı durumlarının (attitude) sürecindeki ARW katkısı: $Q_{\theta} = N^2 \cdot \Delta t$.
+  Yani Kalman, attitude propagation adımı başına $N^2 \Delta t$ kadar belirsizlik
+  ekler.
+- Bias durumlarının rastgele yürüyüş katkısı: $Q_{b} = K^2 \cdot \Delta t$.
+- Bias instability genelde rastgele yürüyüş modelinde **doğrudan girmez** — onun
+  yerine bias için bir birinci dereceden Gauss-Markov modeli kurarsanız zaman
+  sabiti $\tau_b$ ve sürekli-durum σ'sı arasında bir uzlaşmaya gidersiniz; o
+  ayrı bir tuning meselesidir.
+
+Yanlış tuning'in en yaygın hatası ARW'yi `deg/√hr` cinsiyle bırakıp Q matrisine
+SI olmadan girmek. Sonuç: Q ya çok büyük, filtre ölçümleri "izleyemez" hale gelir;
+ya çok küçük, filtre kendine fazla güvenir ve bias üzerine kilitlenir. Bu yüzden
+karakterizasyondan sonra hep `(rad/s)/√Hz` ve `(rad/s)·√s` birimlerine SI'ya çevirin
+ve Q'yu öyle besleyin.
+
+---
+
+## Pratikte tökezleten yedi şey
+
+Bu yazıyı yazarken son birkaç yıldır kendi laboratuvarımda ve okuduğum saha
+raporlarında karşılaştığım yaygın sürtüşmeleri toplamak istedim:
+
+1. **Çok kısa kayıt.** Allan eğrisinin minimumunu yakalamak için kayıt süresinin
+   minimum τ'nun en az 5–10 katı olması gerekir. Eğer beklediğiniz B noktası 1000 s
+   civarındaysa, 1 saatlik kayıtta minimum hâlâ −1/2 eğiminin altındadır ve B'yi
+   "ölçemezsiniz". Pratik kural: en az 6 saat, navigasyon grade için 24+.
+
+2. **Güven aralığı τ büyüdükçe açılır.** Stable32 / AllanTools gibi araçlar χ²
+   tabanlı güven aralığı çizerler; log-log uçlarında eğim okumak için yeterli
+   örnek olmadığını grafik anlamada budur. IEEE 1554-2005 buna karşı uçların
+   son oktavını okumamayı önerir.
+
+3. **Sıcaklık rampaları.** Test odası uzun kayıt sırasında 1-2 derece bile sürüklenirse,
+   eğride yapay bir +1 eğimli rampa belirir ve gerçek RRW ile karışır. Sıcaklığı
+   sabitleyemiyorsanız sıcaklık ölçümü ile birlikte kayıt yapıp veriyi sıcaklığa
+   karşı detrend etmek gerekir.
+
+4. **Montaj titreşimi.** "Kapaktan masa titreşimi geliyor" tipik bir hatadır;
+   küçük τ'larda eğri −1/2'nin üzerinde bir tabana oturur. Atalet sınıfı bir blok
+   üzerine montaj yapmadan, MEMS karakterizasyonu yapmayın.
+
+5. **DC bias kaldırma.** Allan varyansı doğrudan bias'a duyarsızdır ama uzun kayıt
+   öncesi sensörün kendi bias'ını çıkarmanız gerekir, yoksa rampı yanlış yorumlarsınız.
+
+6. **Filtre bandwidth.** Datasheet'lerde "Output Noise (RMS, X Hz BW)" satırı var.
+   Bu, sensörün üzerindeki dahili LPF'in kesim frekansına bağlıdır. Eğer dahili
+   LPF'i devre dışı bırakırsanız beyaz gürültü artar; kayıt sırasında BW'yi sabit
+   ve datasheet ile uyumlu tutun.
+
+7. **MATLAB ve allanvar tuzakları.** MATLAB Sensor Fusion Toolbox'ın `allanvar`
+   fonksiyonu varsayılan olarak overlapping versiyonu döndürür ama `T` argümanına
+   örnekleme zamanı geçilmezse normalize edilmiş, birimsiz değer döner. AllanTools
+   Python kütüphanesi de `data_type='freq'` argümanını unutursanız hız serisini
+   açı (phase) zannedip iki kat türev fazlası uygular.
+
+---
+
+## Allan deviation'ın atom saatlerinden bugüne taşıdığı şey
+
+Atom saati topluluğu, 60'larda standart varyansın sezyum frekans standartlarını
+karşılaştırmak için işe yaramadığını fark etti. Allan'ın çözümü o problemi çözmek
+için doğdu. Sonra telekom dünyası SDH/SONET şebekelerinde aynı aracı *phase noise*
+karakterizasyonu için aldı. 80'lerin sonunda Honeywell, RLG karakterizasyonu için
+metodolojiyi inertial sensorlara taşıdı; bu çalışma IEEE Std 952-1997'nin
+çekirdeğini oluşturdu. 2005'te IEEE 1554, FOG için olan reçeteyi MEMS dahil her tip
+inertial sensora genelledi. Şimdi piyasada bir IMU datasheet'i Allan plot olmadan
+yayımlanmıyor.
+
+Yani bir MEMS jiroskop datasheet'inde gördüğünüz "B = 8 deg/hr" sayısı, bir sezyum
+atom saatinin frekans kararlılığını ölçmek için 1966'da uydurulmuş bir tahmincinin
+direkt mirasıdır. Aynı matematik, atom saatlerinin ürettiği UTC'nin disipline
+ettiği GPS uydularını tasarlayan mühendislere de gidiyor; INS'i GPS ile birleştirmek
+isteyen Kalman filtremize de. Bu yazı bittiğinde elinizde kalan, datasheet'teki o beş
+satırın artık her birinin (a) hangi fiziksel mekanizmadan geldiğini, (b) hangi τ
+ölçeğinde baskın olduğunu, (c) sizin filtrenize SI ile nasıl beslendiğini biliyor
+olmanız.
+
+---
+
+## Kaynaklar
+
+- D. W. Allan, "Statistics of atomic frequency standards," *Proceedings of the IEEE*,
+  vol. 54, no. 2, pp. 221–230, Feb. 1966. — [doi:10.1109/PROC.1966.4634](https://doi.org/10.1109/PROC.1966.4634)
+- IEEE Std 952-1997 (R2008) — "IEEE Standard Specification Format Guide and Test
+  Procedure for Single-Axis Interferometric Fiber Optic Gyros."
+- IEEE Std 1554-2005 — "IEEE Recommended Practice for Inertial Sensor Test Equipment,
+  Instrumentation, Data Acquisition, and Analysis."
+- IEEE Std 528-2001 — "IEEE Standard for Inertial Sensor Terminology."
+- N. El-Sheimy, H. Hou, X. Niu, "Analysis and Modeling of Inertial Sensors Using
+  Allan Variance," *IEEE Transactions on Instrumentation and Measurement*, vol. 57,
+  no. 1, pp. 140–149, Jan. 2008. — [doi:10.1109/TIM.2007.908635](https://doi.org/10.1109/TIM.2007.908635)
+- M. Vagner, "MEMS Gyroscope Performance Comparison Using Allan Variance Method,"
+  Brno University of Technology, 2012. — [PDF](https://home.engineering.iastate.edu/shermanp/AERE432/lectures/Rate%20Gyros/14-xvagne04.pdf)
+- MathWorks, "Inertial Sensor Noise Analysis Using Allan Variance" —
+  [Sensor Fusion and Tracking Toolbox dokümantasyonu](https://www.mathworks.com/help/fusion/ug/inertial-sensor-noise-analysis-using-allan-variance.html)
+- W. J. Riley, *Handbook of Frequency Stability Analysis*, NIST Special Publication
+  1065, 2008.
+- Analog Devices EngineerZone, "Gyroscope Angle Random Walk" —
+  [EZ dokümantasyon sayfası](https://ez.analog.com/mems/w/documents/4509/gyroscope-angle-random-walk)
+- VectorNav, "IMU Specifications Explained" —
+  [vectornav.com inertial primer](https://www.vectornav.com/resources/inertial-navigation-primer/specifications--and--error-budgets/specs-imuspecs)

--- a/agent/research/2026-06-11-allan-deviation-imu-karakterizasyon.md
+++ b/agent/research/2026-06-11-allan-deviation-imu-karakterizasyon.md
@@ -1,0 +1,93 @@
+# Araştırma Notları — Allan Deviation ile IMU/Jiroskop Karakterizasyonu
+
+Tarih: 2026-06-11
+Slug: allan-deviation-imu-karakterizasyon
+Dal: post/2026-06-11-allan-deviation-imu-karakterizasyon
+
+## Konu Seçim Gerekçesi (Faz 2)
+
+- Türkçe içerikte konu son derece dağınık. Türkçe arama yapıldığında çıkan içeriklerin çoğu MATLAB Allan deviation fonksiyonunun nasıl çağrılacağı — matematiksel temel + log-log slope yorumu + somut Python türetmesi birlikte yok.
+- Kalman filtresi yazısının (2026-06-02) doğal yan komşusu: Kalman tuning Q matrisinin diyagonal değerlerini IMU karakterizasyonundan alır. Ama bu yazının konusu Kalman değil — Kalman'a giren parametrelerin nereden geldiği.
+- Atom saatlerinden gelen tarihsel hat (David W. Allan, 1966) → telekom (PTP/SyncE phase noise) → inertial sensorlar → şimdi MEMS jiroskoplar. Bu zincir literatürde nadiren tek seferde anlatılıyor.
+- Derinlik öğesi (Bölüm 7): **matematiksel türetme + tekrar üretilebilir Python deneyi**. Sentetik bir jiroskop veri serisi üzerinde overlapping Allan variance hesaplayıp ARW, B, K parametrelerini geri çıkaracağız.
+- Son 3 yazı alt-alanları: yazılım zanaatı (coupling), navigasyon/füzyon (Kalman), sistem mühendisliği. Bu yazı: **metroloji + sinyal işleme + inertial navigasyon**. Yakın ama çakışmıyor.
+
+## Açık PR Çakışma Kontrolü
+
+- #103 (Kalman Joseph form): farklı — Kalman covariance ıraksaması
+- #114 (Sabit nokta Q15): farklı
+- Diğer açık PR'ların hiçbiri IMU karakterizasyonu / Allan deviation kapsamında değil.
+- Yayında 2026-06-02 Kalman filtresi var — orada Allan deviation kısaca anılıyor ama ana konu değil. Bu yazı o yazının doldurmadığı boşluğu dolduruyor.
+
+## Anahtar Olgular (doğrulandı)
+
+1. **Allan variance tanımı**: σ²_y(τ) = (1/2)·E[(ȳ_{k+1} − ȳ_k)²]
+   - Burada ȳ_k, τ uzunluğundaki k'ıncı kümenin ortalama hız değeri.
+   - Klasik (standart) varyansın aksine, 1/f gürültü için yakınsar.
+   - Kaynak: IEEE Std 952-1997, El-Sheimy et al. 2008.
+
+2. **Overlapping Allan variance** (IEEE 1554-2005 tarafından önerilen):
+   σ²(τ) = 1/(2·m²·(N − 2m + 1)) · Σ_{k=1}^{N−2m+1} (Σ_{i=k}^{k+m−1}(y_{i+m} − y_i))²
+   - Daha iyi istatistiksel verim — aynı veriden daha düşük varyans tahmini.
+
+3. **Log-log Allan deviation eğim → gürültü tipi haritalaması**:
+   | Eğim   | Gürültü tipi             | Parametre (sembol)     |
+   |--------|--------------------------|-------------------------|
+   | −1     | Kuantizasyon gürültüsü   | Q                       |
+   | −1/2   | Açısal rastgele yürüyüş  | N (ARW)                 |
+   | 0      | Bias instability (1/f)   | B                       |
+   | +1/2   | Hız rastgele yürüyüşü    | K (RRW)                 |
+   | +1     | Hız rampı (drift)        | R                       |
+
+4. **Parametre çıkarımı** (IEEE 952-1997):
+   - **N (ARW)**: σ(τ=1 s) = N. Birim: (deg/s)/√Hz veya deg/√s. Saatlik birime: × 60.
+   - **B (bias instability)**: σ_min ≈ 0.664 · B. Faktör: √(2·ln(2)/π) ≈ 0.6643.
+   - **K (RRW)**: σ(τ=3 s) = K. Birim: (deg/s)·√s veya deg/√(s·hr).
+
+5. **Birim dönüşümleri**:
+   - ARW: 1 deg/√s = 60 deg/√hr (zira √3600 = 60).
+   - Bias instability: 1 deg/s = 3600 deg/hr.
+
+6. **Pratik değer aralıkları** (literatürden):
+   - Tüketici MEMS (örn. MPU-6050): ARW ~ 0.1–1 deg/√s, B ~ 10–50 deg/hr
+   - Endüstriyel MEMS (örn. ADIS16470): ARW ~ 0.3 deg/√hr, B ~ 8 deg/hr
+   - Taktiksel grade FOG (örn. KVH DSP-1750): ARW ~ 0.012 deg/√hr, B ~ 0.05 deg/hr
+   - Navigasyon grade RLG (örn. Honeywell GG1320): ARW ~ 0.0035 deg/√hr, B ~ 0.003 deg/hr
+
+7. **Standartlar**:
+   - IEEE Std 952-1997 (R2008) — Single-axis interferometric fiber optic gyros. **Allan variance** burada normatif.
+   - IEEE Std 1554-2005 — Inertial sensor terminology; recommended practice.
+   - IEEE Std 528-2001 — Inertial sensor terminology.
+   - David W. Allan, "Statistics of atomic frequency standards," Proc. IEEE 54(2), 1966.
+
+## Yapı Planı (Faz 4)
+
+1. Giriş — IMU datasheet'inde gördüğümüz beş satır
+2. Allan deviation neden var: standart varyans neden yetmiyor (1/f)
+3. Tarih: atom saatlerinden inertial sensorlara
+4. Matematiksel tanım (klasik + overlapping)
+5. Log-log eğim tablosu: beş gürültü tipinin imzası
+6. Üç parametrenin grafikten okunması: ARW, B, K
+7. Python deneyi: sentetik veri üret → overlapping AVAR hesapla → parametre çıkar
+8. Datasheet karşılaştırması: tüketici vs taktiksel vs navigasyon grade
+9. Kalman filtresine bağlanma: Q matrisi nereden geliyor
+10. Pratik tuzaklar (sıcaklık, montaj, kayıt süresi)
+11. Kaynaklar
+
+## Pratik Tuzaklar (Faz 6 ekleyecek)
+
+- Allan variance'ın güven aralığı τ büyüdükçe çok genişler — log-log uçlarında eğim okumak yanıltıcı.
+- Bias instability'i ölçebilmek için en az B periyodunun ~10 katı kadar veri lazım (saatlerce).
+- Sıcaklık sürüklenmesi Allan plot'a "rampa" gibi görünür ve gerçek RRW ile karışır.
+- Quantization gürültüsü modern 24-bit ADC'lerde nadiren baskındır; eski 12-bit MEMS'te görülür.
+
+## Kaynaklar (yazıda kullanılacak)
+
+- D. W. Allan, "Statistics of atomic frequency standards," Proc. IEEE 54(2):221–230, 1966.
+- IEEE Std 952-1997 — "Specification Format Guide and Test Procedure for Single-Axis Interferometric Fiber Optic Gyros."
+- IEEE Std 1554-2005 — "Recommended Practice for Inertial Sensor Test Equipment, Instrumentation, Data Acquisition, and Analysis."
+- N. El-Sheimy, H. Hou, X. Niu, "Analysis and modeling of inertial sensors using Allan variance," IEEE Trans. Instrum. Meas. 57(1):140–149, 2008.
+- M. Vagner, "MEMS Gyroscope Performance Comparison Using Allan Variance Method," Brno U. of Tech., 2012.
+- MathWorks, "Inertial Sensor Noise Analysis Using Allan Variance" (allanvar fonksiyonu dokümantasyonu).
+- Analog Devices EngineerZone — "Gyroscope Angle Random Walk."
+- VectorNav, "IMU Specifications Explained."

--- a/agent/topics.md
+++ b/agent/topics.md
@@ -22,31 +22,58 @@
 - [x] Ölçüm Belirsizliği (GUM Annex F + NCSLI RP-12) — 2026-05-06 — alan: metroloji
 - [x] Kalibrasyon Zincirinin Tepesi (Birincil Standartlar) — 2026-05-07 — alan: metroloji
 - [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14 — alan: gömülü/SoC
+- [x] Bandpass Sampling — 2026-05-21 — alan: RF/DSP
+- [x] Sistem Mühendisliği Nedir — 2026-05-26 — alan: sistem
+- [x] Kalman Filtresi ve EKF — 2026-06-02 — alan: navigasyon/füzyon
+- [x] Coupling'i Dengelemek — 2026-06-04 — alan: yazılım tasarımı
 
 ## Açık PR'lar (insan inceleme bekleniyor)
 
-| PR # | Başlık | Dal | Açılış | Alan |
-|------|--------|-----|--------|------|
-| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | post/2026-05-20-crc-polinom-secimi-ve-hamming-mesafesi | 2026-05-20 | yazılım zanaatı/hata tespiti |
-| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR Geometrisi | post/2026-05-19-vor-faz-karsilastirma | 2026-05-19 | navigasyon |
-| [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A | post/2026-05-18-mcdc-kapsama-do-178c-dal-a | 2026-05-17 | sertifikasyon |
-| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi (C/C++, Rust) | post/bellek-guvenligi-devrimi | 2026-04-12 | gömülü/güvenlik |
-| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış (Undefined Behavior) | blog/undefined-behavior | 2026-04-04 | C/derleyici |
-| [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | blog/misra-c-statik-analiz | 2026-03-28 | standart/C (#69 ile çakışma riski!) |
-| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ (eski yazı genişletme) | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
+| PR # | Başlık | Açılış | Alan |
+|------|--------|--------|------|
+| _(yeni — bu çalıştırma)_ | Allan Deviation: IMU Datasheet'inin Gizli Dilini Çözmek | 2026-06-11 | metroloji/sinyal işleme/inertial |
+| [#124](https://github.com/mavrikant/mavrikant.github.io/pull/124) | Yüksek İrtifada Sessiz Hata — SEU, SECDED ECC ve Bellek Scrubbing | 2026-06-10 | gömülü/güvenilirlik |
+| [#122](https://github.com/mavrikant/mavrikant.github.io/pull/122) | Endianness'in Üç Katmanı — ARM BE-8/BE-32, Bitfield ve 1553/429 | 2026-06-09 | C/protokol |
+| [#121](https://github.com/mavrikant/mavrikant.github.io/pull/121) | Lockstep CPU Mimarileri — Cortex-R5 DCLS, CCM-R5 ve DAL A | 2026-06-08 | ARM/güvenilirlik |
+| [#120](https://github.com/mavrikant/mavrikant.github.io/pull/120) | Priority Inversion ve Mars Pathfinder — FreeRTOS'ta Yeniden Üretim | 2026-06-08 | RTOS |
+| [#119](https://github.com/mavrikant/mavrikant.github.io/pull/119) | DMA ve Cache — Cortex-A9 / Zynq-7000 üzerinde sessiz veri bozulması | 2026-06-07 | ARM/gömülü |
+| [#118](https://github.com/mavrikant/mavrikant.github.io/pull/118) | DO-326A ve ED-202A — Aviyonik Siber Güvenlik Sertifikasyonu | 2026-06-05 | sertifikasyon/güvenlik |
+| [#114](https://github.com/mavrikant/mavrikant.github.io/pull/114) | Sabit Nokta Aritmetik — Cortex-M0'da Q15 FIR Filtresi | 2026-06-04 | gömülü/DSP |
+| [#103](https://github.com/mavrikant/mavrikant.github.io/pull/103) | Kalman Filtresinin Sessiz Iraksaması — Joseph Form | 2026-06-01 | navigasyon/füzyon |
+| [#102](https://github.com/mavrikant/mavrikant.github.io/pull/102) | ILS Anatomisi — Localizer 90/150 Hz DDM ve Glide Path | 2026-05-31 | navigasyon |
+| [#101](https://github.com/mavrikant/mavrikant.github.io/pull/101) | ARM GIC — Cortex-A Kesme Denetleyicisi | 2026-05-30 | ARM |
+| [#100](https://github.com/mavrikant/mavrikant.github.io/pull/100) | `volatile` Yetmediğinde — Zynq-7000 C11 `_Atomic` | 2026-05-29 | C/eşzamanlılık |
+| [#99](https://github.com/mavrikant/mavrikant.github.io/pull/99) | Dört Aşamalı Veri Analitiği — Mühendislikte | 2026-05-28 | matematik |
+| [#98](https://github.com/mavrikant/mavrikant.github.io/pull/98) | WCET Analizi — Statik, Ölçüm, Cache'in Karanlık Tarafı | 2026-05-28 | gerçek-zamanlı |
+| [#96](https://github.com/mavrikant/mavrikant.github.io/pull/96) | Fault Tree Analizi ve Minimal Cut Set | 2026-05-27 | güvenilirlik |
+| [#90](https://github.com/mavrikant/mavrikant.github.io/pull/90) | Linker Script Anatomisi — ARM Bare-Metal `.ld` | 2026-05-26 | gömülü |
+| [#89](https://github.com/mavrikant/mavrikant.github.io/pull/89) | Watchdog Timer Tasarım Desenleri — Rendezvous Pattern | 2026-05-24 | güvenilirlik |
+| [#88](https://github.com/mavrikant/mavrikant.github.io/pull/88) | WCET Analizi: Statik mi, Ölçüm mü, Hibrit mi? | 2026-05-23 | gerçek-zamanlı (#98 ile çakışma!) |
+| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | 2026-05-20 | yazılım zanaatı/hata tespiti |
+| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR | 2026-05-19 | navigasyon |
+| [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A | 2026-05-17 | sertifikasyon |
+| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi (C/C++, Rust) | 2026-04-12 | gömülü/güvenlik |
+| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış (Undefined Behavior) | 2026-04-04 | C/derleyici |
+| [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | 2026-03-28 | standart/C (yayındaki MISRA C:2025 ile çakışma!) |
+| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ | 2026-03-26 | gömülü/sayısal |
 
-> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. İnceleyen kişinin dikkatine.
+> **Not (insan dikkatine):** Backlog 24 açık PR'a ulaştı. İki açık çakışma var:
+> #98 ile #88 (her ikisi de WCET); #51 ile yayındaki MISRA C:2025. Bir de çok eski
+> PR'lar (#50, #51, #54, #67) hâlâ bekliyor. Yeni yazı açmadan önce mevcutları
+> kapatmak/merge etmek değerlendirmeye değer.
 
 ## Seçildi / Devam Eden
 
-- **Bandpass Sampling: 1 GHz Sinyali 50 MHz Saatle Örneklemek** —
-  dal: `post/2026-05-21-bandpass-sampling`,
-  dosya: `_posts/2026-05-21-bandpass-sampling.md`,
-  durum: PR açılacak (bu çalıştırma) — alan: RF/DSP.
+- **Allan Deviation: IMU Datasheet'inin Gizli Dilini Çözmek** —
+  dal: `post/2026-06-11-allan-deviation-imu-karakterizasyon`,
+  dosya: `_posts/2026-06-11-allan-deviation-imu-karakterizasyon.md`,
+  araştırma: `agent/research/2026-06-11-allan-deviation-imu-karakterizasyon.md`,
+  durum: PR açıldı (2026-06-11) — alan: metroloji + sinyal işleme + inertial.
 
 ## Reddedildi (bu çalıştırma)
 
-- _(bu çalıştırmada konu reddedilmedi; bandpass sampling havuzdan seçildi.)_
+- _(bu çalıştırmada aday reddedilmedi; Allan deviation fikir havuzunda yoktu —
+  doğrudan boşluk analizinden, Kalman yazısının yan komşusu olarak çıktı.)_
 
 ## Fikir Havuzu (aday konular — gelecek çalıştırma için)
 
@@ -57,72 +84,69 @@ geçici olarak karşılıyor. Faz 2'de tekrar değerlendirilmesi gerekir.
 
 - [ ] **ARM Cortex-A reset vektöründen `main()`'e: gerçekten ne oluyor?** —
       alan: gömülü/SoC — Renode yazısının doğal devamı, somut deney imkânı
-- [ ] **MC/DC kapsama: DO-178C DAL A'da neden modified condition/decision şart?** —
-      alan: sertifikasyon — gerçek karar tablosu örneği, decision/condition farkı
-- [ ] **CRC vs checksum: neden CRC-32 değil de CRC-32C / CRC-16-CCITT seçilir?** —
-      alan: yazılım zanaatı — polinom seçimi, hata tespit gücü, bit-hata analizi
-- [ ] **WCET analizi: statik analiz vs ölçüm tabanlı yaklaşımlar, cache etkileri** —
-      alan: gerçek zamanlı — somut örnek (örn. Cortex-R5 üzerinde basit görev)
+- [ ] **Cache coherency ve MESI: ARM'da CCI/CMN ne yapar, neden yazılım perde
+      (barrier) gerekir?** — alan: ARM — pratik race condition örneği (DMA/cache
+      yazısı #119 farklı bir açıdan ele aldı, MESI iç işleyişi hâlâ boşluk)
+- [ ] **MPU vs MMU: hangisi ne zaman, FreeRTOS-MPU örneği** — alan: ARM/RTOS
 - [ ] **IQ örnekleme ve karmaşık sinyaller: gerçek SDR'ye giriş** —
       alan: RF/SDR — neden negatif frekans, neden 2 kanal
-- [ ] **GIC (Generic Interrupt Controller): SGI/PPI/SPI farkları ve önceliklendirme** —
-      alan: ARM — kesme yönlendirme, multicore'da CPU affinity
-- [ ] **Cache coherency ve MESI: ARM'da CCI/CMN ne yapar, neden yazılım perde
-      (barrier) gerekir?** — alan: ARM — pratik race condition örneği
-- [ ] **Linker script anatomisi: ARM bare-metal için bir `.ld` dosyası satır satır** —
-      alan: gömülü — kendi linker script'i yazma rehberi
-- [ ] **Watchdog tasarım desenleri: tek vs çoklu görev watchdog, deadman switch,
-      windowed watchdog** — alan: güvenilirlik — gerçek tasarım kararları
-- [ ] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
-      alan: C/eşzamanlılık — derleyici çıktı analizi
-- [ ] **VOR'un çalışma prensibi: 30 Hz referans + değişken faz nasıl yön verir?** —
-      alan: navigasyon — faz farkı matematiği + sinyal şeması
-- [ ] **ILS anatomisi: localizer 90/150 Hz DDM ve glide slope** —
-      alan: navigasyon — modülasyon derinliği farkı + örnek hesap
-- [ ] **Kalman filtresi tuzakları: numerik stabilite, gözlemlenebilirlik, tuning** —
-      alan: navigasyon/füzyon — basit IMU örneği + Python kodu
-- [ ] **Sabit nokta (Q-format) aritmetik: Cortex-M0'da FPU yokken DSP nasıl yapılır?** —
-      alan: gömülü/DSP — Q15/Q31 örnekleri, overflow yönetimi
+- [ ] **FIR vs IIR: faz cevabı, hesaplama maliyeti, stabilite** — alan: DSP
+- [ ] **ARINC 653: zaman ve uzay bölümlemesi, schedule table tasarımı** —
+      alan: aviyonik OS — DAL A için zorunlu mimari
+- [ ] **ARINC 653 health monitoring: PROCESS/PARTITION/MODULE hata seviyeleri** —
+      alan: aviyonik OS — gerçek tasarım kararları
+- [ ] **Rate Monotonic Scheduling: Liu & Layland %69.3 sınırı türetmesi** —
+      alan: gerçek-zamanlı — matematiksel derinlik
+- [ ] **DO-330 araç nitelendirme (Tool Qualification) seviyeleri TQL-1..TQL-5** —
+      alan: sertifikasyon
+- [ ] **ARP4754A — sistem geliştirme süreci** — alan: sertifikasyon
+- [ ] **FMEA pratikte: gerçek bir alt-sistem üzerinden adım adım** — alan: güvenilirlik
+- [ ] **Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain** —
+      alan: araçlar/sertifikasyon
+- [ ] **Statik analiz neyi yakalar / kaçırır: somut C kodu üzerinden** —
+      alan: araçlar (yayındaki MISRA C:2025'i tamamlar)
+- [ ] **ADS-B sinyal yapısı: PPM modülasyon, mesaj formatı, downlink kodları** —
+      alan: aviyonik haberleşme
+- [ ] **PPS ve zaman senkronizasyonu: IRIG-B, NTP, PTP** — alan: zaman
+- [ ] **Allan deviation'ın atom saatleri tarafı: phase noise spektrumu, σ_y(τ) ↔ S_φ(f)** —
+      alan: zaman/metroloji — bu çalıştırmadaki Allan yazısının saat tarafından gelen yan komşusu
 
 ### Orta öncelikli (kovaya alındı)
 
-- [ ] DO-330 araç nitelendirme (Tool Qualification) seviyeleri
-- [ ] ARP4754A — sistem geliştirme süreci
-- [ ] DO-326A / ED-202A havacılık siber güvenliği
-- [ ] FMEA pratikte: gerçek bir alt-sistem üzerinden adım adım
-- [ ] Fault Tree Analysis ile minimal cut set hesabı
-- [ ] FPU denormal performansı: Cortex-A vs x86 davranış farkı
-- [ ] Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain
-- [ ] Endianness: ağ baytı vs host baytı, ARM'ın iki modu, bitfield tuzakları
-- [ ] DMA yarış koşulları: ARM'da cache invalidation/clean stratejileri
-- [ ] Lockstep CPU mimarisi: TI Hercules / NXP MPC57xx örnekleri
-- [ ] MPU vs MMU: hangisi ne zaman, FreeRTOS-MPU örneği
-- [ ] Statik analiz neyi yakalar / kaçırır: somut C kodu üzerinden Coverity/Polyspace
-- [ ] Radyasyona dayanıklı yazılım: SEU, TMR, scrubbing
-- [ ] ADS-B sinyal yapısı: PPM modülasyon, mesaj formatı
-- [ ] FIR vs IIR: faz cevabı, hesaplama maliyeti, stabilite
-
-### Düşük öncelikli / sonraya bırak
-
+- [ ] FPU denormal performansı: Cortex-A vs x86 davranış farkı (PR #50 ile dikkatli ol)
 - [ ] ECSS uzay yazılım standartları ailesi (geniş, alt-konulara bölünmeli)
 - [ ] DO-254 donanım sertifikasyonu (yazarın uzmanlığı ağırlıklı yazılım tarafında)
 - [ ] İzlenebilirlik matrisi (klasik konu, derinlik çıkarmak zor)
+- [ ] Bootloader tasarımı: A/B partitioning, signed firmware, anti-rollback
+- [ ] CMSIS-DSP vs naive C: Cortex-M4 üzerinde performans karşılaştırması
+- [ ] Stack analizi: worst-case stack usage analysis araçları ve yöntem
+- [ ] GPS L1 C/A: Gold kodu üretimi ve korelasyon
 
-## Notlar (bu çalıştırma — 2026-05-21)
+### Düşük öncelikli / sonraya bırak
 
-- **Bandpass Sampling** seçildi (alan: RF/DSP). Önceki çalıştırmaların ardından
-  açılan PR'lar son üç alt-alanı (sertifikasyon #77, navigasyon #78, yazılım
-  zanaatı/CRC #79) işaretlemişti; bu yazı **bu üç alandan da** son yayınlanan 3
-  posttan da (Renode gömülü/SoC, kalibrasyon ×2) farklı bir alan getiriyor.
-- Yayın kapısı durumu: Bölüm 4 yalnızca "yayın PR ile olmalı" kuralı koyar; backlog
-  büyüklüğüne dair sert bir sınır yoktur. Açık 7 PR olmasına rağmen son yayınlanan
-  yazıdan (Renode, 2026-05-14) bu yana 7 gün geçti — `min_yayin_araligi_gun = 2`
-  şartı fazlasıyla sağlanmış durumda. Bu çalıştırmada yeni PR açıldı.
-- Bandpass sampling konusunun "neden Türkçe içerikte zor bulunuyor" yanıtı:
-  matematik (Vaughan 1991), datasheet okuma (analog input BW), saat phase noise
-  ve filtre tasarımı disiplinlerinin kesişiminde bulunuyor; Türkçe kaynaklar
-  genellikle yalnızca tek bir cepheden ele almış oluyor (genelde Lyons özet
-  çevirisi). Sentez ve somut sayısal örnek boşluğu büyük.
-- Açık PR'lar konusunda inceleme önceliği yorumu (gözlem): #50 ve #51 hâlâ uzun
-  süredir bekliyor; #50 eski yazıyı genişletiyor, #51 ise yayındaki MISRA C:2025
-  ile büyük olasılıkla çakışıyor. İnceleyen kişinin dikkatine.
+- [ ] GNSS multipath mitigation: narrow correlator, MEDLL
+- [ ] Time-triggered architectures / TTEthernet (niş)
+- [ ] AFDX (ARINC 664 Part 7): switched ethernet for aviation
+
+## Notlar (bu çalıştırma — 2026-06-11)
+
+- **Allan Deviation** seçildi (alan: metroloji + sinyal işleme + inertial). Konu
+  fikir havuzunda yoktu; geçen haftaki Kalman yazısının (2026-06-02) Q matrisi
+  parametrelerinin nereden geldiği sorusunu yanıtsız bıraktığını fark ettim. Bu
+  yazı o boşluğu dolduruyor ama Kalman'la çakışmıyor — Kalman *parametreleri
+  kullanır*, bu yazı *parametrelerin nereden geldiğini* anlatır.
+- "Türkçe içerikte neden zor bulunuyor" yanıtı: Allan deviation konusu üç ayrı
+  disiplinin (frekans metrolojisi, sinyal işleme, inertial navigasyon) kesişiminde.
+  Türkçe kaynakların çoğu MATLAB fonksiyon çağrısı düzeyinde kalıyor; matematik
+  + log-log slope yorumu + somut Python türetmesi tek yerde yok. IEEE 952-1997
+  standardı paywall arkasında olduğu için "neden 0.664" sorusunun cevabı dağınık.
+- Derinlik öğesi (Bölüm 7): **matematiksel türetme + tekrar üretilebilir Python
+  deneyi** (sentetik veri → overlapping AVAR → parametre geri çıkarımı).
+- Son 3 yazı alt-alanı: yazılım tasarımı (coupling), navigasyon/füzyon (Kalman),
+  sistem mühendisliği. Bu yazının alanı (metroloji + sinyal işleme + inertial)
+  ikisinden de farklı — alan rotasyonu sağlandı.
+- Yayın kapısı durumu: son yayın 2026-06-04 → 7 gün geçti, `min_yayin_araligi_gun = 2`
+  fazlasıyla sağlandı. Backlog (24 açık PR) büyük; bu konuya Bölüm 4 sert sınır
+  koymuyor ama insan inceleyiciye not bıraktım.
+- Faz 6'da iki düzeltme yapıldı: (a) "yedi büyüklük mertebesi" → dört + iki buçuk,
+  (b) "5–8 derece" tüketici MEMS biriciktirme → "1–8 derece" (B aritmetiği ile).


### PR DESCRIPTION
## Yazı

**Allan Deviation: IMU Datasheet'inin Gizli Dilini Çözmek** — `_posts/2026-06-11-allan-deviation-imu-karakterizasyon.md`

IMU/jiroskop datasheet'lerinde sürekli karşımıza çıkan ARW (Angular Random Walk),
bias instability ve rate random walk parametrelerinin matematiksel temelini,
nereden geldiklerini ve Kalman filtresine nasıl beslendiklerini açıklayan
uzun-form bir yazı.

## Seçim gerekçesi

- **Konu:** Allan deviation ile inertial sensor karakterizasyonu.
- **Neden bu konu:** Geçen haftaki Kalman filtresi yazısı (2026-06-02) proses
  gürültü kovaryans matrisi Q'nun parametrelerini kullanıyor ama bu sayıların
  *nereden geldiği* yazıda yer almıyor. Bu boşluğu doldurur ama Kalman ile
  çakışmaz — biri parametreleri kullanır, biri parametrelerin nereden geldiğini
  anlatır.
- **Açık PR çakışma kontrolü:** Açık 24 PR taraması temiz. Allan
  deviation/inertial karakterizasyon konusu hiçbir açık PR'da ya da yayında yok.
  En yakını PR #103 (Kalman Joseph form) — o tamamen farklı bir alt-konu.

## Derinlik öğesi (Bölüm 7)

Bu yazı **iki** somut derinlik öğesi taşıyor:

1. **Matematiksel türetme** — Allan varyansının klasik ve overlapping
   formülasyonları, log-log eğim ↔ gürültü tipi haritalaması, parametre
   çıkarım formülleri (özellikle σ_min ≈ 0.664·B sabitinin türetimi:
   √(2·ln(2)/π)).
2. **Tekrar üretilebilir Python deneyi** — sentetik bir jiroskop hız serisi
   bilinen N, B, K değerleriyle üretiliyor, overlapping Allan deviation
   sıfırdan hesaplanıyor, sonra parametreler grafikten geri okunuyor.
   Tohum sabit (`20260611`) — okuyucu kodu birebir çalıştırıp sonucu
   doğrulayabilir.

## "Bu konuyu Türkçe içerikte bulmak neden zor?"

Allan deviation üç ayrı disiplinin (frekans metrolojisi, sinyal işleme,
inertial navigasyon) kesişiminde. Türkçe içeriklerin çoğu MATLAB'in `allanvar`
fonksiyonunu çağırıp bırakıyor; matematik + log-log slope yorumu + somut Python
türetmesi tek bir kaynakta yok. IEEE Std 952-1997 paywall arkasında olduğu
için "neden 0.664" gibi sorulara cevap dağınık. Yazı bu sentezi tek yerde
yapmaya çalışıyor.

## Kullanılan kaynaklar

- D. W. Allan, "Statistics of atomic frequency standards," Proc. IEEE 1966
- IEEE Std 952-1997, IEEE Std 1554-2005, IEEE Std 528-2001
- El-Sheimy/Hou/Niu, IEEE Trans. Instrum. Meas. 57(1), 2008
- W. J. Riley, NIST SP 1065 Handbook of Frequency Stability Analysis, 2008
- MathWorks Sensor Fusion Toolbox dokümantasyonu
- Analog Devices EngineerZone, VectorNav inertial primer

## Öz-eleştiri özeti (Faz 6'da düzeltilenler)

- "Yedi büyüklük mertebesi" iddiası gerçek datasheet aralıkları kontrol
  edildi ve "B'de yaklaşık dört, ARW'de iki buçuk büyüklük mertebesi" olarak
  düzeltildi.
- "Kalibre edilmemiş hâlde 10 dakikada 5–8 derece" iddiası — bias instability
  aritmetiği yeniden yapıldı (8 deg/hr × 1/6 hr = 1.33 deg; 50 deg/hr × 1/6 hr =
  8.3 deg) ve "1–8 derece" şeklinde düzeltildi.

## Yayın kapısı kontrolleri (Bölüm 13)

- [x] Konu hiçbir yayın/açık PR ile başlık veya anlam olarak çakışmıyor
- [x] Altı seçim kriterinin tamamı sağlanıyor; son 3 yazıdan farklı alt-alan
- [x] Novelty sorusu yanıtlandı (yukarıda)
- [x] En az bir somut derinlik öğesi var (aslında iki)
- [x] Her olgusal iddia doğrulanabilir; standart numaraları, formüller, sabitler kontrol edildi
- [x] Kaynaklar gerçek ve erişilebilir
- [x] Gizli/proje-spesifik/ihracat-kontrollü bilgi yok — tamamı kamuya açık standart ve literatür
- [x] Ön bilgi bloğu mevcut yazıların şemasıyla birebir aynı (coupling-dengesi ve kalman-filtresi ile karşılaştırıldı)
- [x] Türkçe + İngilizce alt-başlık var; birinci tekil şahıs, "sahadan" ton
- [x] Anti-pattern yok; derinlik gerçek
- [x] Dosya adı + dal adı kurallı
- [x] `master`'a hiçbir şey push edilmedi; teslim yalnızca PR
- [x] `agent/topics.md` defteri güncellendi (yayın listesi + açık PR tablosu + fikir havuzu)

## Defter güncellemeleri

- "Yazıldı" listesine eksik yazılar eklendi (Bandpass Sampling, Sistem
  Mühendisliği, Kalman, Coupling).
- Açık PR tablosu 24 PR ile yeniden yazıldı; #88/#98 (her ikisi de WCET) ve
  #51/yayındaki MISRA C:2025 çakışmaları insan dikkatine işaretlendi.
- Fikir havuzuna yeni yüksek-değer adaylar eklendi: ARINC 653, Rate Monotonic
  Scheduling türetmesi, Allan deviation'ın saat tarafından gelen yan komşusu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
