### PR TITLE
sm_thumbnails: animasyonlu WebP kapaklarda derleme hatasını gider

### DIFF
--- a/_plugins/sm_thumbnails.rb
+++ b/_plugins/sm_thumbnails.rb
@@ -66,9 +66,12 @@ module SmThumbnails
     def copy_file(dest_path)
       cmd = SmThumbnails.magick_command
       ok = system(
-        cmd, @source_image,
-        "-resize", "#{WIDTH}x>", # cap width at WIDTH, never enlarge
-        "-strip",                # drop metadata
+        cmd, "#{@source_image}[0]", # first frame only: animated WebP backgrounds
+                                    # can't be re-encoded as a resized animation by
+                                    # IM6 (WriteAnimatedWEBPImage fails), and the
+                                    # card thumbnail only needs a still image
+        "-resize", "#{WIDTH}x>",    # cap width at WIDTH, never enlarge
+        "-strip",                   # drop metadata
         "-quality", QUALITY.to_s,
         dest_path
       )


### PR DESCRIPTION
## Sorun

`master`'a yapılan son merge sonrası **Build and Deploy to Github Pages** workflow'u başarısız oldu:

```
convert-im6.q16: ERROR adding frame: Invalid frame dimensions.
  .../_site/img/posts/sm/coupling-dengesi-cover.webp @ error/webp.c/WriteAnimatedWEBPImage/972.
_plugins/sm_thumbnails.rb:77: sm_thumbnails: failed to generate sm/coupling-dengesi-cover.webp (RuntimeError)
```

`_plugins/sm_thumbnails.rb`, her yazı kapağından 768px'lik kart küçük görseli üretiyor. Yeni **animasyonlu** kapak için ImageMagick (IM6), yeniden boyutlandırılmış animasyonu yazarken `WriteAnimatedWEBPImage` adımında hata veriyor.

## Çözüm

Kart küçük görseli zaten hareketsiz olabileceğinden, ImageMagick'e kaynağın yalnızca **ilk karesini** (`[0]`) veriyoruz. Bu, hem animasyonlu hem statik kaynaklar için doğru çalışır ve animasyon-yazma hatasını tamamen ortadan kaldırır.

## Doğrulama

Aynı ortamda (IM6 `convert`) yeniden üretildi:

- Eski komut (tüm animasyon): `exit 1`, aynı `WriteAnimatedWEBPImage` hatası.
- Yeni komut (`[0]`): `exit 0`, temiz 768×480 statik küçük görsel (~6 KB).

https://claude.ai/code/session_018fZvWfD67JWXJoouZcqSbF

---
_Generated by [Claude Code](https://claude.ai/code/session_018fZvWfD67JWXJoouZcqSbF)_