### PR TITLE
Tasarım cilası: erişilebilir odak halkası, başlık çapa bağlantıları ve başa dön düğmesi

### DIFF
--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -266,6 +266,20 @@ hr {
   text-shadow: none;
 }
 
+// =============================================================================
+// Accessible focus ring — a single, consistent accent outline shown only for
+// keyboard navigation. Mouse/touch clicks keep a clean look (no outline);
+// :focus-visible restores a clear ring for keyboard users.
+// =============================================================================
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 // Container/page background
 .container {
   // Make sure containers inherit the themed background
@@ -1189,6 +1203,40 @@ div.highlight {
     padding: 0.05em 0.08em 0 0;
     margin-right: 0.05em;
   }
+
+  // Heading anchors — hover-revealed deep link injected by assets/scripts.js.
+  // Hidden by default on pointer devices; visible on heading hover or when the
+  // anchor itself receives keyboard focus.
+  h2, h3, h4 {
+    .heading-anchor {
+      display: inline-flex;
+      align-items: center;
+      margin-left: 0.35rem;
+      color: var(--color-text-subtle);
+      opacity: 0;
+      text-decoration: none;
+      vertical-align: middle;
+      transition: opacity 0.18s ease, color 0.18s ease;
+
+      svg { display: block; }
+
+      &:hover { color: var(--color-accent); }
+    }
+
+    &:hover .heading-anchor,
+    .heading-anchor:focus-visible {
+      opacity: 1;
+    }
+  }
+}
+
+// Touch devices have no hover — keep heading anchors quietly visible.
+@media (hover: none) {
+  .post-content h2 .heading-anchor,
+  .post-content h3 .heading-anchor,
+  .post-content h4 .heading-anchor {
+    opacity: 0.6;
+  }
 }
 
 .post-content {
@@ -1363,6 +1411,48 @@ article {
   }
 
   &.is-empty { display: none !important; }
+}
+
+// =============================================================================
+// Floating scroll-to-top button — injected by assets/scripts.js, revealed
+// once the reader has scrolled past the first viewport.
+// =============================================================================
+.scroll-top {
+  position: fixed;
+  right: clamp(1rem, 3vw, 2rem);
+  bottom: clamp(1rem, 3vw, 2rem);
+  z-index: 1040; // below modals (2000) and the reading progress bar (1100)
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+  color: var(--color-accent-contrast);
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(12px);
+  transition: opacity 0.25s ease, transform 0.25s ease,
+              visibility 0.25s ease, background-color 0.2s ease;
+
+  svg { display: block; }
+
+  &.is-visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--color-accent-hover);
+    transform: translateY(-3px);
+  }
 }
 
 // =============================================================================
@@ -2432,6 +2522,8 @@ article {
   .lightbox,
   .copy-code-btn,
   .back-to-top,
+  .scroll-top,
+  .heading-anchor,
   .post-heading__tags,
   #disqus_thread,
   #disqus_thread + script + script + noscript,

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -184,6 +184,74 @@
   }
 
   // ---------------------------------------------------------------------------
+  // Heading anchors: hover-revealed deep links on article headings (h2-h4).
+  // Reuses any id already assigned by the TOC builder; assigns one otherwise so
+  // every section is directly linkable.
+  // ---------------------------------------------------------------------------
+  var ANCHOR_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>';
+
+  function initHeadingAnchors() {
+    var content = document.querySelector('.post-content');
+    if (!content) return;
+
+    var headings = content.querySelectorAll('h2, h3, h4');
+    var usedIds = {};
+
+    headings.forEach(function (h) {
+      if (!h.id) {
+        var base = slugify(h.textContent || '') || 'section';
+        var id = base;
+        var i = 2;
+        while (usedIds[id] || document.getElementById(id)) {
+          id = base + '-' + i++;
+        }
+        h.id = id;
+      }
+      usedIds[h.id] = true;
+
+      if (h.querySelector('.heading-anchor')) return;
+
+      var a = document.createElement('a');
+      a.className = 'heading-anchor';
+      a.href = '#' + h.id;
+      a.setAttribute('aria-label', 'Bu bölüme bağlantı');
+      a.innerHTML = ANCHOR_ICON;
+      h.appendChild(a);
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scroll-to-top: floating button revealed after the first viewport of scroll.
+  // ---------------------------------------------------------------------------
+  function initScrollTop() {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'scroll-top';
+    btn.setAttribute('aria-label', 'Başa dön');
+    btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15"/></svg>';
+    document.body.appendChild(btn);
+
+    var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    btn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
+    });
+
+    var ticking = false;
+    function update() {
+      ticking = false;
+      btn.classList.toggle('is-visible', window.scrollY > window.innerHeight * 0.8);
+    }
+
+    window.addEventListener('scroll', function () {
+      if (!ticking) {
+        ticking = true;
+        window.requestAnimationFrame(update);
+      }
+    }, { passive: true });
+    update();
+  }
+
+  // ---------------------------------------------------------------------------
   // Mobile navbar: toggle .show on the responsive collapse target.
   // Replaces the Bootstrap 4 jQuery collapse handler so we can drop tooltip
   // initialization without losing the menu toggle.
@@ -652,6 +720,8 @@
     initThemeToggle();
     initCodeEnhancements();
     initPostToc();
+    initHeadingAnchors();
+    initScrollTop();
     initNavbarToggle();
     initNavbarDropdowns();
     initBayramSplash();


### PR DESCRIPTION
## Özet

Site tasarımı zaten oldukça olgun (tasarım jetonları, koyu tema, arama, içindekiler tablosu, okuma ilerleme çubuğu, lightbox, sayfa geçişleri). Mevcut estetiği bozmadan, eksik olan üç profesyonel cilayı ekledim. Tümü yalnızca CSS + JS; hiçbir layout/markup değişikliği yok.

## Değişiklikler

**1. Erişilebilir odak halkası (`:focus-visible`)**
- Klavyeyle gezinenler için tutarlı, vurgu renkli bir dış çizgi (`outline`) eklendi.
- Fare/dokunma tıklamalarında varsayılan dış çizgi gizlenir; yalnızca klavye odağında halka görünür.
- Bağlantılar, gezinme öğeleri, etiket rozetleri, kartlar, form alanları ve simge düğmeleri artık tek tip bir odak göstergesine sahip.

**2. Başlık çapa bağlantıları (yazı sayfaları)**
- Yazı içeriğindeki `h2`–`h4` başlıklara, imleçle (veya klavye odağıyla) belirginleşen derin bağlantı çapaları eklendi.
- Mevcut içindekiler tablosuyla aynı başlık kimliklerini paylaşır; her bölüm doğrudan bağlanabilir hale gelir.
- Dokunmatik cihazlarda (hover yok) çapalar hafifçe görünür kalır.

**3. Yüzen "başa dön" düğmesi**
- Uzun sayfalarda ilk ekran kaydırıldıktan sonra beliren, sağ alta sabitlenmiş bir düğme.
- Özellikle uzun teknik yazılarda ve mobilde kullanışlı; alttaki footer bağlantısını tamamlar.
- `prefers-reduced-motion` ve yazdırma (print) stilleriyle uyumlu.

## Doğrulama
- `bundle exec jekyll build` başarıyla tamamlandı (exit 0); SCSS sorunsuz derlendi.
- `node -c assets/scripts.js` ile JS söz dizimi doğrulandı.
- Derlenen `main.css` içinde yeni kuralların doğru basamak (cascade) sırasında yer aldığı teyit edildi.

https://claude.ai/code/session_01DH2MDmccjTh24zYR4PgRAM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH2MDmccjTh24zYR4PgRAM)_