### PR TITLE
feat: auto-convert images to WebP in PRs

### DIFF
--- a/.github/workflows/convert-to-webp.yml
+++ b/.github/workflows/convert-to-webp.yml
@@ -1,0 +1,75 @@
+name: Convert Images to WebP
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'img/**/*.jpg'
+      - 'img/**/*.jpeg'
+      - 'img/**/*.png'
+      - 'img/**/*.gif'
+      - 'img/**/*.JPG'
+      - 'img/**/*.JPEG'
+      - 'img/**/*.PNG'
+      - 'img/**/*.GIF'
+
+concurrency:
+  group: convert-to-webp-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  convert:
+    name: Convert to WebP
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install WebP tools
+        run: sudo apt-get install -y webp
+
+      - name: Convert JPEG/PNG to WebP
+        run: |
+          find img/ -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 \
+            | while IFS= read -r -d '' file; do
+                base="${file%.*}"
+                if cwebp -q 85 "$file" -o "${base}.webp"; then
+                  rm "$file"
+                  echo "Converted: $file → ${base}.webp"
+                fi
+              done
+
+      - name: Convert animated GIF to WebP
+        run: |
+          find img/ -type f -iname "*.gif" -print0 \
+            | while IFS= read -r -d '' file; do
+                base="${file%.*}"
+                if gif2webp "$file" -o "${base}.webp"; then
+                  rm "$file"
+                  echo "Converted: $file → ${base}.webp"
+                fi
+              done
+
+      - name: Update image references in posts
+        run: |
+          find _posts/ -name "*.md" -print0 \
+            | xargs -0 sed -i \
+                -e 's/\.\(jpg\|jpeg\|png\|gif\)/.webp/gI'
+
+      - name: Commit converted images
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add img/ _posts/
+          if git diff --staged --quiet; then
+            echo "No images to convert."
+          else
+            git commit -m "chore: convert images to WebP format [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## Summary

Closes #24

- `img/` klasörüne jpg/jpeg/png/gif dosyası eklenen her PR'da otomatik olarak WebP formatına dönüştürür
- `cwebp -q 85` ile JPEG/PNG, `gif2webp` ile animasyonlu GIF → animasyonlu WebP dönüşümü yapar
- Orijinal dosyaları siler ve yerine `.webp` uzantılı versiyonlarını koyar
- `_posts/*.md` dosyalarındaki referansları da otomatik günceller (`.jpg` → `.webp` vb.)
- Dönüştürülen dosyalar `github-actions[bot]` tarafından aynı PR branch'ine commit edilir

## Test plan

- [ ] `img/` altına test amaçlı bir `.jpg` veya `.png` dosyası ekleyerek PR aç
- [ ] Workflow'un tetiklendiğini ve dosyayı `.webp`'ye çevirip commit ettiğini doğrula
- [ ] `_posts/` içinde referans güncellenmesini kontrol et
- [ ] Animasyonlu GIF için `gif2webp` dönüşümünü doğrula

https://claude.ai/code/session_01MRf1NU7HiTynxJSC7huZSG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRf1NU7HiTynxJSC7huZSG)_