### PR TITLE
Koyu tema diyagram/grafik uyumu ve mobil/tablet içindekiler

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,6 @@
 <link rel="preload" as="font" type="font/woff2" crossorigin href="{{ "/assets/fonts/inter-var-latin-ext.woff2" | relative_url }}">
 <link rel="preload" as="font" type="font/woff2" crossorigin href="{{ "/assets/fonts/source-serif-4-var-latin-ext.woff2" | relative_url }}">
 {% if page.background %}<link rel="preload" as="image" href="{{ page.background | prepend: site.baseurl | replace: '//', '/' }}" fetchpriority="high">{% endif %}
-{% if page.mermaid %}<script async src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.12.0/mermaid.min.js" integrity="sha512-5TKaYvhenABhlGIKSxAWLFJBZCSQw7HTV7aL1dJcBokM/+3PNtfgJFlv8E6Us/B1VMlQ4u8sPzjudL9TEQ06ww==" crossorigin="anonymous"></script>{% endif %}
 <link rel="stylesheet" href="{{"/assets/main.css" | relative_url }}">
 <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
 <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">

--- a/_includes/post-toc.html
+++ b/_includes/post-toc.html
@@ -1,4 +1,8 @@
 <aside class="post-toc" aria-label="İçindekiler">
+  <button class="post-toc__toggle" type="button" aria-expanded="false" aria-controls="post-toc-nav">
+    <span>İçindekiler</span>
+    <svg class="post-toc__chevron" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+  </button>
   <h2 class="post-toc__title">İçindekiler</h2>
   <nav id="post-toc-nav"></nav>
 </aside>

--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -1375,29 +1375,42 @@ article {
 .post-shell { position: relative; }
 
 .post-toc {
-  display: none;
+  // Small/medium screens: collapsible card above the article body.
+  display: block;
+  margin: 0 0 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-alt);
+  overflow: hidden;
 
-  @media (min-width: 1280px) {
-    display: block;
-    position: absolute;
-    top: 0;
-    left: calc(100% + 2rem);
-    width: 220px;
-    height: 100%;
-
-    nav {
-      position: sticky;
-      top: 100px;
-      max-height: calc(100vh - 140px);
-      overflow-y: auto;
-      padding-left: 1rem;
-      border-left: 2px solid var(--color-border);
-      font-family: var(--font-sans);
-      font-size: 0.85rem;
-    }
+  &__toggle {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.7rem 1rem;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--color-heading);
   }
 
+  &__chevron {
+    flex-shrink: 0;
+    color: var(--color-text-subtle);
+    transition: transform 0.2s ease;
+  }
+
+  &.is-open &__chevron { transform: rotate(180deg); }
+
+  // The <h2> title is the sidebar header on desktop; on small screens the
+  // toggle button serves as the header instead.
   &__title {
+    display: none;
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -1406,12 +1419,20 @@ article {
     font-weight: 700;
   }
 
+  nav {
+    display: none;
+    padding: 0 1rem 0.85rem;
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+  }
+
+  &.is-open nav { display: block; }
+
   ul { list-style: none; padding: 0; margin: 0; }
 
   a {
     display: block;
     padding: 0.3rem 0 0.3rem 0.7rem;
-    margin-left: -0.7rem;
     color: var(--color-text-muted);
     text-decoration: none;
     border-left: 2px solid transparent;
@@ -1431,7 +1452,48 @@ article {
     font-size: 0.8rem;
   }
 
+  // Desktop: sticky sidebar to the right of the article (original layout).
+  @media (min-width: 1280px) {
+    position: absolute;
+    top: 0;
+    left: calc(100% + 2rem);
+    width: 220px;
+    height: 100%;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    overflow: visible;
+
+    .post-toc__toggle { display: none; }
+    .post-toc__title { display: block; }
+
+    nav {
+      display: block;
+      position: sticky;
+      top: 100px;
+      max-height: calc(100vh - 140px);
+      overflow-y: auto;
+      padding: 0 0 0 1rem;
+      border-left: 2px solid var(--color-border);
+      font-size: 0.85rem;
+    }
+
+    a { margin-left: -0.7rem; }
+  }
+
   &.is-empty { display: none !important; }
+}
+
+// Plotly charts are authored with light backgrounds and hand-tuned label
+// colors. In dark mode, frame them as deliberate light figures (rather than
+// recolouring every annotation, which would leave some labels unreadable).
+[data-theme="dark"] .post-content .js-plotly-plot {
+  background: #ffffff;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
 }
 
 // =============================================================================

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -153,6 +153,22 @@
 
     nav.appendChild(ul);
 
+    // Collapsible toggle (small screens — sidebar is always open on >=1280px)
+    var toggle = toc.querySelector('.post-toc__toggle');
+    if (toggle) {
+      toggle.addEventListener('click', function () {
+        var open = toc.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      });
+      // Collapse after following a link on small screens
+      nav.addEventListener('click', function (e) {
+        if (e.target.closest('a') && window.matchMedia('(max-width: 1279.98px)').matches) {
+          toc.classList.remove('is-open');
+          toggle.setAttribute('aria-expanded', 'false');
+        }
+      });
+    }
+
     // Scroll spy
     if (!('IntersectionObserver' in window)) return;
 
@@ -654,6 +670,69 @@
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Mermaid: load on demand and render with the active theme. Loading mermaid
+  // ourselves (instead of letting it auto-start from <head>) lets us pick the
+  // dark/light theme before the first render and re-render on theme changes.
+  // ---------------------------------------------------------------------------
+  function initMermaid() {
+    var nodes = Array.prototype.slice.call(document.querySelectorAll('.mermaid'));
+    if (!nodes.length) return;
+
+    // Stash each diagram's source before mermaid replaces it with an SVG.
+    nodes.forEach(function (n) {
+      if (!n.hasAttribute('data-mermaid-src')) {
+        n.setAttribute('data-mermaid-src', n.textContent.trim());
+      }
+    });
+
+    function currentTheme() {
+      return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'default';
+    }
+
+    function render() {
+      if (!window.mermaid) return;
+      nodes.forEach(function (n) {
+        n.removeAttribute('data-processed');
+        n.innerHTML = n.getAttribute('data-mermaid-src');
+      });
+      window.mermaid.initialize({ startOnLoad: false, theme: currentTheme() });
+      try { window.mermaid.run({ nodes: nodes }); } catch (e) {}
+    }
+
+    var loaded = false;
+    function load() {
+      if (loaded) return;
+      loaded = true;
+      var s = document.createElement('script');
+      s.src = 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.12.0/mermaid.min.js';
+      s.integrity = 'sha512-5TKaYvhenABhlGIKSxAWLFJBZCSQw7HTV7aL1dJcBokM/+3PNtfgJFlv8E6Us/B1VMlQ4u8sPzjudL9TEQ06ww==';
+      s.crossOrigin = 'anonymous';
+      s.onload = render;
+      document.head.appendChild(s);
+    }
+
+    load();
+    document.addEventListener('themechange', function () {
+      if (window.mermaid) render();
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Plotly: charts are authored with light backgrounds. In dark mode, keep the
+  // hand-tuned light figure but frame it so it reads as a deliberate figure
+  // rather than a glaring untreated block. Re-fit on theme change so Plotly
+  // recomputes the responsive size after the framing margin shifts.
+  // ---------------------------------------------------------------------------
+  function initPlotlyTheme() {
+    if (!window.Plotly) return;
+    document.addEventListener('themechange', function () {
+      document.querySelectorAll('.js-plotly-plot').forEach(function (gd) {
+        try { window.Plotly.Plots.resize(gd); } catch (e) {}
+      });
+    });
+  }
+
   function ready(fn) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', fn);
@@ -731,5 +810,7 @@
     initShareCopy();
     initLightbox();
     initGiscusThemeSync();
+    initMermaid();
+    initPlotlyTheme();
   });
 })();

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -694,7 +694,9 @@
       if (!window.mermaid) return;
       nodes.forEach(function (n) {
         n.removeAttribute('data-processed');
-        n.innerHTML = n.getAttribute('data-mermaid-src');
+        // Diagram source is plain text (Mermaid reads textContent); assigning
+        // via textContent avoids reinterpreting it as HTML.
+        n.textContent = n.getAttribute('data-mermaid-src');
       });
       window.mermaid.initialize({ startOnLoad: false, theme: currentTheme() });
       try { window.mermaid.run({ nodes: nodes }); } catch (e) {}


### PR DESCRIPTION
# Özet

Canlı kontrolde doğrulanan iki kusuru gideriyor: koyu temada Mermaid diyagramları soluk açık temayla, Plotly grafikleri beyaz arka planla kalıyordu. Ayrıca içindekiler (TOC) yalnızca masaüstünde (≥1280px) görünüyordu.

## Koyu tema diyagram/grafik

**Mermaid → gerçek koyu tema.** Mermaid artık `<head>`'den otomatik (async) yüklenmek yerine `assets/scripts.js` tarafından yükleniyor; böylece ilk render'dan önce aktif tema seçilebiliyor ve tema değiştirilince diyagram **canlı yeniden çiziliyor**. Otomatik yüklemenin kaldırılması açık→koyu flash'ını ve çift render'ı önler. SRI (integrity) hash'i dinamik script'te korunuyor; CSP zaten cdnjs'e izin veriyor.

**Plotly → çerçeveli açık figür.** Grafikler elle ayarlanmış gömülü etiket/anotasyon renkleri içeriyor; bunları JS ile yeniden boyamak bazı etiketleri okunmaz yapardı. Bunun yerine koyu temada grafikler kenarlık + gölge + köşe yarıçapıyla **kasıtlı bir açık figür** olarak çerçeveleniyor — tüm etiketler okunur kalıyor, parlayan işlenmemiş blok görüntüsü gidiyor. Tema değişiminde `Plotly.Plots.resize` ile yeniden boyutlanıyor.

## Mobil/tablet içindekiler

TOC artık **<1280px'de makalenin üstünde açılır/katlanır bir kart**; ≥1280px'de önceki yapışkan kenar çubuğu davranışı aynen korunuyor. Dar ekranda bir bağlantıya tıklanınca panel otomatik katlanır. <3 başlıklı yazılarda gizlenme davranışı değişmedi.

## Doğrulama (yerel build, Chromium)
- ✅ Mermaid koyu temada koyu kutular + açık metin; açığa geçince geri dönüyor (canlı re-render)
- ✅ Plotly koyu temada beyaz figür + 1px koyu kenarlık + gölge + 10px radius
- ✅ Mobil (390px): TOC katlanmış başlar, toggle ile açılıp 17 bağlantı gösteriyor, bağlantı tıklayınca katlanıyor
- ✅ Masaüstü (1440px): TOC hâlâ yapışkan kenar çubuğu (position:absolute, toggle gizli)
- ✅ `<head>`'de mermaid script'i yok; `.mermaid` div'leri ve JS yüklemesi yerinde

## Not
Başlık kalıcı bağlantıları (¶) zaten master'da mevcut olduğu için bu PR'a dahil edilmedi.

https://claude.ai/code/session_01WTGZkJmz8kWoNU8WY6DeVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTGZkJmz8kWoNU8WY6DeVC)_