### PR TITLE
Upgrade Ruby, Jekyll and dependencies to latest

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.4'
           bundler-cache: true
 
       - name: Build site

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for AI assistants (Claude Code and similar tools) wo
 
 ## Project Overview
 
-This is the personal blog of **M. Serdar Karaman**, hosted at <https://karaman.dev>. It is a static site built with **Jekyll 4.2** using the **Start Bootstrap Clean Blog** theme. The blog covers software engineering, programming (C, C++, Qt, Python), Linux, avionics, and related topics. Most posts are written in Turkish (`lang: tr`).
+This is the personal blog of **M. Serdar Karaman**, hosted at <https://karaman.dev>. It is a static site built with **Jekyll 4.4** using the **Start Bootstrap Clean Blog** theme. The blog covers software engineering, programming (C, C++, Qt, Python), Linux, avionics, and related topics. Most posts are written in Turkish (`lang: tr`).
 
 - **Live site:** <https://karaman.dev>
 - **Source branch:** `master` (GitHub Actions deploys to `gh-pages`)
@@ -58,7 +58,7 @@ This is the personal blog of **M. Serdar Karaman**, hosted at <https://karaman.d
 
 ## Tech Stack
 
-- **Static site generator:** Jekyll `~> 4.2.0`
+- **Static site generator:** Jekyll `~> 4.4`
 - **Theme:** [Start Bootstrap Clean Blog Jekyll](https://startbootstrap.com/themes/clean-blog-jekyll/) (forked/vendored)
 - **Markdown:** kramdown
 - **Sass:** compressed output
@@ -103,7 +103,7 @@ Output goes to `_site/` (gitignored).
 
 Deployment is automated via GitHub Actions:
 
-- `.github/workflows/build-jekyll.yml` — on push to `master`, uses `jeffreytse/jekyll-deploy-action@v0.6.0` to build and publish to the `gh-pages` branch. Ruby 3.2.0 and a compatible Bundler `~>2.5.0` are used. ImageMagick is installed as a pre-build dependency.
+- `.github/workflows/build-jekyll.yml` — on push to `master`, builds with `ruby/setup-ruby@v1` (Ruby 3.4, Bundler cached) and publishes to the `gh-pages` branch via `peaceiris/actions-gh-pages@v4`. ImageMagick (with the WebP delegate) is installed as a pre-build dependency.
 
 Other workflows:
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 4.2.0" 
+gem "jekyll", "~> 4.4"
 gem "webrick"
 
 group :jekyll_plugins do
@@ -16,7 +16,7 @@ group :jekyll_plugins do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:windows, :jruby]
 
 # Performance-booster for watching directories on Windows
 gem "wdm" if Gem.win_platform?


### PR DESCRIPTION
## Summary

Upgrades Ruby, Jekyll and all dependencies to their latest releases, and verifies they build together compatibly.

### Changes
- **`Gemfile`**: Jekyll constraint `~> 4.2.0` → `~> 4.4` (resolves **4.4.1**). Modernized `tzinfo-data` platforms to `:windows`, removing the Bundler deprecation warning for `:mingw`/`:mswin`/`:x64_mingw`.
- **`.github/workflows/build-jekyll.yml`**: CI Ruby `3.2` → `3.4`.
- **`CLAUDE.md`**: refreshed version/deploy references to match (and corrected the stale deploy description to the actual `ruby/setup-ruby` + `peaceiris/actions-gh-pages` workflow).

All `jekyll_plugins` are unpinned and resolve to their latest releases:

| Gem | Version |
|---|---|
| jekyll | 4.4.1 |
| jekyll-feed | 0.17.0 |
| jekyll-paginate | 1.1.0 |
| jekyll-sitemap | 1.4.0 |
| jekyll-admin | 0.12.0 |
| jekyll-seo-tag | 2.9.0 |
| jekyll-email-protect | 1.1.0 |
| jekyll-spaceship | 0.10.2 |
| jekyll-favicon | 1.1.0 |
| jekyll-coffeescript | 2.0.0 |
| webrick | 1.9.2 |

### Compatibility testing
Verified a clean `bundle install` + `bundle exec jekyll build` (`JEKYLL_ENV=production`) under both **Ruby 3.4.9** (latest stable, the new CI target, with Bundler 2.6.9) and Ruby 3.3.6:

- ✅ Build completes with exit 0 (only pre-existing Bootstrap Sass `@import`/`if()` deprecation warnings).
- ✅ `index.html`, `feed.xml`, `sitemap.xml`, paginated `/posts/`, `about/` and `main.css` all generated.
- ✅ `sm_thumbnails.rb` plugin generated all 17 responsive WebP card thumbnails via ImageMagick.
- ✅ `jekyll-favicon` generated `favicon.ico` / `favicon.png`.
- ✅ MathJax still loads from jsDelivr; no real `polyfill.io` `<script>` reintroduced by the jekyll-spaceship upgrade (the config override still applies).

### Notes
- No `Gemfile.lock` is committed (gitignored, per repo convention), so plugins continue to float to their latest compatible releases at install time.
- The upstream theme `jekyll-theme-clean-blog.gemspec` is intentionally left unchanged (it is not loaded by the `Gemfile` build).

https://claude.ai/code/session_01UdHER2XsuGUwWhUBBDMMXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdHER2XsuGUwWhUBBDMMXV)_