### PR TITLE
Gerçek zamanlı sistemler hakkında blog yazısı ekle

### DIFF
--- a/_posts/2026-06-24-gercek-zamanli-sistemler-hard-soft-best-effort.md
+++ b/_posts/2026-06-24-gercek-zamanli-sistemler-hard-soft-best-effort.md
@@ -1,6 +1,6 @@
 ---
-title: "Gerçek Zamanlı Sistemler: Hızlı Olmak ile Zamanında Olmak Aynı Şey Değildir"
-subtitle: "Real-Time Systems: Hard, Firm, Soft, Best-Effort and Beyond"
+title: "Gerçek Zamanlı Sistemler: Hızlı Değil, Zamanında"
+subtitle: "Hard, Firm, Soft and Best-Effort Real-Time Systems"
 background: "/img/posts/2.webp"
 date: '2026-06-24 09:00:00'
 layout: post
@@ -10,44 +10,29 @@ categories: [muhendislik]
 tags: [gercek-zamanli-sistemler, gomulu-sistemler, aviyonik]
 ---
 
-İki "gecikme" düşünün. İlki: akşam dizinizi izlerken görüntü 200 milisaniye takılıyor, bir kare donuyor, sonra düzeliyor. Canınız sıkılır, belki söylenirsiniz, ama hayat devam eder. İkincisi: bir kaza anında hava yastığını ateşleyecek sinyal, olması gerekenden 50 milisaniye geç geliyor. Bu kez ortada can sıkıntısı yoktur; ortada bir trajedi vardır.
+Akşam dizi izlerken görüntü yarım saniye donar, sonra kendine gelir. Sinir olursunuz, geçer. Aynı yarım saniye, bir kaza anında hava yastığını ateşleyecek sinyalin gecikmesi olduğunda ise ortada sinir değil, bir trajedi vardır.
 
-İki olayda da sistem "geç kaldı". Ama birinde gecikmenin bedeli bir homurtu, diğerinde bir insan hayatı. İşte **gerçek zamanlı sistemler** (*real-time systems*) tam da bu farkın üzerine kurulur. Yaygın sanının aksine gerçek zamanlılık "ne kadar hızlı" sorusu değildir; "**ne zaman**" sorusudur. Bir sonucun doğru olması yetmez — *zamanında* da olmak zorundadır. Geç gelen doğru cevap, çoğu zaman yanlış cevaptır.
-
-Bu yazıda önce "gerçek zamanlı" kelimesinin en çok yanlış anlaşılan yanını netleştireceğiz; sonra bir deadline kaçırıldığında ne olduğuna göre sistemleri bir spektruma yerleştireceğiz — **hard, firm, soft, best-effort** ve **none**. Ardından bir sistemi gerçek zamanlı yapan şeyin ne olduğuna ve bunun pratikte nasıl sağlandığına bakacağız. En sonunda da bu beşli spektrumun *tek* sınıflandırma ekseni olmadığını, gerçek zamanlı sistemlerin başka hangi açılardan ayrıştığını göreceğiz.
+İki olayda da sistem geç kaldı; ama birinde bedeli bir homurtu, diğerinde bir hayat. Gerçek zamanlı sistemler kavramı tam da bu farkın üzerine kuruludur. Yaygın sanının aksine mesele "ne kadar hızlı" değil, "ne zaman" sorusudur: bir sonucun doğru olması yetmez, zamanında da gelmesi gerekir. Geç gelen doğru cevap çoğu zaman yanlış cevaptır.
 
 ---
 
-## "Gerçek Zamanlı" Hızlı Demek Değildir
+## Gerçek Zamanlı, Hızlı Demek Değil
 
-En baştan bir yanılgıyı dağıtalım: gerçek zamanlı, hızlı demek değildir. Saniyede milyarlarca işlem yapan bir sunucu gerçek zamanlı olmayabilir; saniyede yalnızca yüz işlem yapan mütevazı bir mikrodenetleyici ise kusursuz biçimde gerçek zamanlı olabilir.
+Önce en sık yapılan hatayı dağıtalım. Saniyede milyarlarca işlem yapan bir sunucu gerçek zamanlı olmayabilir; saniyede yüz işlem yapan ufak bir mikrodenetleyici kusursuz biçimde gerçek zamanlı olabilir. Fark hızda değil, **determinizmde** (öngörülebilirlik): bir işin ortalama ne kadar sürdüğü değil, en kötü ihtimalle ne kadar süreceğinin garanti altında olması.
 
-Aradaki fark **determinizmdir** (*determinism*) — yani öngörülebilirlik. Gerçek zamanlı bir sistemde önemli olan, bir işin *ortalama* ne kadar sürdüğü değil, **en kötü ihtimalle** ne kadar süreceğinin garanti altında olmasıdır. Bir işlem bazen 1 milisaniyede, bazen 2 milisaniyede, ama nadiren de olsa 100 milisaniyede bitiyorsa, ortalaması ne kadar parlak olursa olsun o sistem güvenilmezdir. Çünkü gerçek zamanlı dünyada sizi vuran şey ortalama değil, o ender görülen en kötü andır.
+Bir işlem çoğu zaman 1 ms'de bitip nadiren 100 ms'ye çıkıyorsa, ortalaması ne kadar iyi olursa olsun o sistem güvenilmezdir. Çünkü sizi vuran şey ortalama değil, o ender görülen en kötü andır.
 
-Bu yüzden sözlüğümüze üç kavram girer:
+Üç kavram işin sözlüğünü oluşturur:
 
-- **Deadline (son teslim anı):** Bir işin tamamlanmış olması gereken zaman sınırı. Gerçek zamanlılığın kalbidir.
-- **Gecikme (*latency*):** Bir olayın (bir sensör tetiklemesi, bir kesme) gerçekleşmesi ile sistemin ona yanıt vermesi arasında geçen süre.
-- **Seğirme (*jitter*):** Bu gecikmenin ölçümden ölçüme ne kadar değiştiği. Her döngüde tam tamına 10 ms'de yanıt veren bir sistem düşük seğirmelidir; bazen 8 bazen 14 ms'de yanıt veren sistem ise yüksek seğirmelidir — ve gerçek zamanlı tasarımda seğirme çoğu zaman ham hızdan daha kıymetlidir.
-
-Özetle: gerçek zamanlı bir sistem, "olabildiğince hızlı" çalışan değil, "**her zaman söz verdiği süre içinde**" çalışan sistemdir.
-
----
-
-## Anahtar Fikir: Değerin Zamanla Değişmesi
-
-Sistemleri sınıflandıran zarif fikir şudur: bir sonucun değeri zamanla nasıl değişir? Bir işi deadline'ından *önce* bitirirseniz tam değeri alırsınız. Peki ya deadline kaçarsa? İşte cevabın şekli, sistemin hangi sınıfa girdiğini belirler.
-
-- Kimi sistemde deadline geçtiği an değer **uçuruma düşer**: sonuç yalnızca değersiz olmakla kalmaz, aktif olarak zarar verir.
-- Kimisinde değer aniden **sıfıra iner**: geç gelen sonuç işe yaramaz, ama en azından zararı da yoktur.
-- Kimisinde değer **kademeli olarak azalır**: geç gelir, biraz değer kaybeder, ama hâlâ bir işe yarar.
-- Kimisinde ise deadline diye keskin bir çizgi zaten yoktur; sadece "ne kadar erken, o kadar iyi" geçerlidir.
-
-Bu "değer fonksiyonunun" şekli, aşağıdaki beş sınıfı birbirinden ayıran asıl ölçüttür. Şimdi spektrumu en katısından en gevşeğine doğru gezelim.
+- **Deadline:** İşin tamamlanmış olması gereken an.
+- **Gecikme** (*latency*): Bir olay ile sistemin ona verdiği yanıt arasındaki süre.
+- **Seğirme** (*jitter*): Bu gecikmenin ölçümden ölçüme ne kadar oynadığı. Her döngüde tam 10 ms'de yanıt veren bir sistem iyidir; bazen 8 bazen 14 ms diyen sistem kötüdür. Kontrol döngülerinde seğirme çoğu zaman ham hızdan daha kıymetlidir.
 
 ---
 
 ## Spektrum: Hard, Firm, Soft, Best-Effort, None
+
+Sistemleri sınıflandıran soru tektir: deadline kaçarsa sonucun değerine ne olur? Kiminde değer uçuruma düşer, kiminde sıfırlanır, kiminde yavaşça erir, kiminde de deadline diye keskin bir çizgi zaten yoktur. Beş sınıf bu cevaba göre dizilir.
 
 <div class="mermaid">
 flowchart LR
@@ -59,136 +44,73 @@ flowchart LR
     style E fill:#cfe8cf,stroke:#2e7d32,stroke-width:2px
 </div>
 
-Soldan sağa gidildikçe zaman kısıtının sertliği azalır, esneklik artar. Önce her birini tek tek görelim, sonra hepsini bir tabloda toplayalım.
+Soldan sağa zaman kısıtının sertliği azalır.
 
-### Hard (Katı) Gerçek Zamanlı
+### Hard (Katı)
 
-En tavizsiz uçtur. Bir tek deadline kaçırmak bile sistemin tümden başarısız sayılması demektir; sonuç çoğu zaman felakettir — maddi hasar, yaralanma, ölüm. Burada "geç gelen doğru cevap" yalnızca yararsız değil, tehlikelidir.
+En tavizsiz uç. Tek bir deadline kaçırmak bile sistemi tümden başarısız kılar ve sonuç çoğu zaman felakettir: maddi hasar, yaralanma, ölüm. Uçağın uçuş kontrol bilgisayarı, otomobilin hava yastığı ve ABS denetleyicisi, bir kalp pili, nükleer santralin acil kapatma sistemi... Bu sistemlerin doğruluğu "ne hesapladığına" değil, "tam olarak ne zaman hesapladığına" bağlıdır. Hava yastığı milisaniyeler içinde açılmazsa hiç açılmamış sayılır.
 
-Klasik örnekler güvenlik-kritik dünyadan gelir: bir uçağın **uçuş kontrol bilgisayarı**, otomobilin **hava yastığı** ve **ABS** (kilitlenmeyi önleyen fren) denetleyicisi, bir **kalp pili**, nükleer santralin acil kapatma sistemi. Bu sistemlerin doğruluğu yalnızca "ne hesapladığına" değil, "**tam olarak ne zaman** hesapladığına" bağlıdır. Hava yastığı milisaniyeler içinde açılmazsa hiç açılmamış gibidir.
+### Firm (Sıkı)
 
-### Firm (Sıkı) Gerçek Zamanlı
+Bir adım gevşemiştir. Deadline kaçarsa sonuç değersizdir; atılır, kullanılmaz. Ama bu sistemi yıkmaz. Hard'dan farkı, gecikmiş sonucun bedelinin sıfır olması, negatif olmaması. Üretim hattında doğru anı kaçıran robot kolunun çıkardığı parça ıskartaya gider; üzücüdür ama fabrika patlamaz. Zamanı geçmiş bir borsa emri ya da geç kalmış bir video karesi de öyledir: en doğrusu onu hiç kullanmamaktır. Firm sistemler ara sıra deadline kaçırmaya tahammül eder, yeter ki bu sık olmasın.
 
-Bir adım gevşemiştir. Deadline kaçırılırsa sonuç **değersizdir** — atılır, kullanılmaz — ama bu, sistemi yıkmaz. Hard ile farkı şudur: gecikmiş sonucun bedeli sıfırdır, *negatif* değil. Üstelik firm sistemler ara sıra deadline kaçırmaya tahammül edebilir; yeter ki bu sık olmasın.
+### Soft (Esnek)
 
-Örneğin bir endüstriyel üretim hattında, robot kolu doğru anı kaçırırsa o parça ıskartaya çıkar; üzücüdür ama fabrika patlamaz, bir sonraki parçaya geçilir. Benzer biçimde geç hesaplanmış bir borsa emri ya da zamanı geçmiş bir video karesi: işe yaramaz, en doğrusu onu hiç göstermemektir.
-
-### Soft (Esnek) Gerçek Zamanlı
-
-Burada deadline keskin bir uçurum değil, yumuşak bir yokuştur. Deadline kaçtığında sonuç hâlâ bir **değer taşır**, sadece geciktikçe bu değer azalır. Amaç deadline'a "her zaman" değil, "çoğunlukla" uymak ve kalite ile gecikme arasında makul bir denge tutturmaktır.
-
-En tanıdık örnekler günlük hayatımızdan: **video/ses akışı** (bir kare biraz geç gelse de izleyici çoğu zaman fark etmez), **VoIP/görüntülü görüşme**, çevrimiçi **oyunlar**, ve genel olarak bir uygulamanın **arayüz tepkiselliği**. Bir butona bastığınızda 100 ms yerine 150 ms'de yanıt almak rahatsız edicidir ama yıkıcı değildir.
+Burada deadline keskin bir uçurum değil, yumuşak bir yokuştur. Sonuç geç gelse de hâlâ işe yarar, sadece geciktikçe değeri azalır. Hedef, deadline'a "her zaman" değil "çoğunlukla" uymaktır. Video ve ses akışı, VoIP, çevrimiçi oyunlar, bir uygulamanın arayüz tepkiselliği... Bir butona bastığınızda 100 yerine 150 ms'de yanıt almak rahatsız edicidir ama yıkıcı değildir.
 
 ### Best-Effort (Elden Geldiğince)
 
-Artık katı bir deadline garantisi yoktur. Sistem "elinden gelenin en iyisini" yapar: kaynakları olabildiğince verimli paylaştırır, ortalama tepkiselliği ve verimi (*throughput*) yüksek tutmaya çalışır, ama hiçbir tek isteğin belirli bir süre içinde biteceğine **söz vermez**.
-
-İnternetin temel teslim modeli budur (*best-effort delivery*): paketler genellikle hızlı ulaşır, ama hiçbir zaman garanti yoktur. Bir **web sunucusunun** istekleri yanıtlaması, genel amaçlı bir işletim sisteminin süreçleri zamanlaması da böyledir — hedef "adil ve hızlı", ama "garantili" değil.
+Artık katı bir deadline garantisi yoktur. Sistem elinden gelenin en iyisini yapar: kaynağı verimli paylaştırır, ortalama tepkiselliği ve verimi (*throughput*) yüksek tutmaya çalışır, ama hiçbir tek isteğin belirli bir süre içinde biteceğine söz vermez. İnternetin teslim modeli (*best-effort delivery*) tam böyledir. Bir web sunucusunun istekleri karşılaması veya genel amaçlı bir işletim sisteminin süreçleri zamanlaması da aynı kategoridedir: hedef "adil ve hızlı", ama "garantili" değil.
 
 ### None (Gerçek Zamanlı Olmayan)
 
-En gevşek uç. Zamanlama, doğruluğun bir parçası bile değildir. İş ne zaman biterse bitsin, sonuç aynı ölçüde geçerlidir; tek dert genel olarak işin makul bir sürede tamamlanmasıdır.
-
-Gece çalışan **toplu yedekleme** işleri, ay sonu **rapor üretimi**, çevrimdışı veri analizleri, bir derleyicinin kodu derlemesi... Bunlar bir dakika erken ya da geç bitsin, kimsenin umurunda değildir. Burada "deadline" kavramı mühendislik anlamında yoktur.
+En gevşek uç. Zamanlama, doğruluğun bir parçası bile değildir. İş ne zaman biterse bitsin sonuç aynı ölçüde geçerlidir. Gece çalışan toplu yedeklemeler, ay sonu raporları, çevrimdışı veri analizleri, bir derleyicinin kodu derlemesi... Bunların mühendislik anlamında bir deadline'ı yoktur.
 
 ### Hepsi Bir Arada
 
 | Sınıf | Deadline kaçarsa | Tipik örnek |
 |---|---|---|
 | **Hard** | Felaket; sonuç zararlı | Uçuş kontrol, hava yastığı, kalp pili, ABS |
-| **Firm** | Sonuç değersiz (ama zararsız), atılır | Endüstriyel üretim adımı, geç video karesi |
-| **Soft** | Sonucun değeri kademeli azalır | Video/ses akışı, VoIP, oyun, arayüz |
+| **Firm** | Sonuç değersiz (ama zararsız), atılır | Üretim adımı, geç video karesi |
+| **Soft** | Değer kademeli azalır | Video/ses akışı, VoIP, oyun, arayüz |
 | **Best-effort** | Garanti yok; "elinden geleni yap" | Web sunucusu, internet paket teslimi, genel OS zamanlama |
-| **None** | Önemli değil; zamanlama doğruluğun parçası değil | Gece yedekleme, çevrimdışı rapor, derleme |
+| **None** | Önemli değil | Gece yedekleme, çevrimdışı rapor, derleme |
 
-Önemli bir not: Bu sınıflar bütün bir cihazı değil, **tek tek görevleri** etiketler. Tek bir akıllı telefonun içinde aynı anda hard (modem/radyo zamanlaması), soft (video oynatma) ve none (arka planda fotoğraf yedekleme) görevleri yaşar. Mesele "bu sistem hangi sınıf?" değil, "bu *görevin* deadline'ı kaçarsa ne olur?" sorusudur.
-
----
-
-## Bir Sistemi Gerçek Zamanlı Yapan Nedir?
-
-Madem hız değil, peki nedir? Tek kelimeyle: **garanti**. Gerçek zamanlı bir sistem, en kötü senaryoda bile deadline'ına uyacağını *önceden kanıtlayabilen* sistemdir. Bu güvence birkaç temel kavrama dayanır:
-
-- **WCET (En Kötü Durum Yürütme Süresi, *Worst-Case Execution Time*):** Bir görevin tamamlanmasının *en fazla* ne kadar süreceği. Gerçek zamanlı mühendis ortalama süreyle değil, bu en kötü değerle çalışır; çünkü garanti ancak en kötü duruma göre verilebilir. Bu yüzden çoğu zaman önbellek (*cache*), dallanma tahmini gibi "ortalamayı iyileştiren ama en kötü durumu öngörülemez kılan" mekanizmalar gerçek zamanlı tasarımda göze batar.
-- **Sınırlı gecikme:** Bir olaya yanıt süresinin bir üst sınırının olması ve bu sınırın asla aşılmaması.
-- **Düşük seğirme:** Yanıt süresinin ölçümden ölçüme neredeyse hiç değişmemesi. Özellikle kontrol döngülerinde, sürekli ama biraz oynak bir gecikme, daha büyük ama *sabit* bir gecikmeden çok daha kötü olabilir.
-
-Buradaki asıl zihniyet kayması şudur: gündelik yazılımda "çoğu zaman hızlı olsun, ara sıra yavaşlasa da olur" makbuldür. Gerçek zamanlı dünyada ise tam tersi geçerlidir — **biraz daha yavaş ama her seferinde aynı** olmak, ortalamada parlayıp ara sıra takılmaya yeğdir. Performans burada [fonksiyonel olmayan bir gereksinim]({% post_url 2022-07-11-fonksiyonel-olmayan-yazilim-gereksinimleri %}) olarak değil, doğruluğun ayrılmaz bir parçası olarak ele alınır.
+Dikkat: bu sınıflar koca bir cihazı değil, tek tek **görevleri** etiketler. Bir akıllı telefonun içinde aynı anda hard (modem zamanlaması), soft (video oynatma) ve none (arka planda fotoğraf yedekleme) görevleri yaşar. Doğru soru "bu sistem hangi sınıf?" değil, "bu *görevin* deadline'ı kaçarsa ne olur?"dur.
 
 ---
 
-## Bu Garanti Nasıl Sağlanır?
+## Garantiyi Nasıl Veriyoruz?
 
-Öngörülebilirlik kendiliğinden gelmez; tasarlanır. Birkaç temel araç:
+Madem hız değil, bir sistemi gerçek zamanlı yapan ne? Tek kelimeyle **garanti**: en kötü senaryoda bile deadline'a uyacağını önceden kanıtlayabilmek. Bu birkaç araca dayanır.
 
-**Gerçek zamanlı işletim sistemi (RTOS).** Genel amaçlı bir işletim sistemi (masaüstü Linux, Windows) verimi ve adilliği önceler; bir görevin tam olarak ne zaman çalışacağını garanti etmez. Bir **RTOS** ise (FreeRTOS, VxWorks, QNX, Zephyr ya da gerçek zaman yaması uygulanmış Linux — `PREEMPT_RT`) öngörülebilirliği her şeyin önüne koyar: en yüksek öncelikli görevin, sınırlı ve bilinen bir süre içinde işlemciye kavuşacağını taahhüt eder.
+**WCET** (en kötü durum yürütme süresi, *worst-case execution time*). Mühendis ortalamayla değil bu en kötü değerle çalışır; çünkü garanti ancak en kötü duruma göre verilebilir. Bu yüzden önbellek (*cache*) ve dallanma tahmini gibi "ortalamayı iyileştiren ama en kötü durumu öngörülemez kılan" mekanizmalar gerçek zamanlı tasarımda göze batar. Performans burada [fonksiyonel olmayan bir gereksinim]({% post_url 2022-07-11-fonksiyonel-olmayan-yazilim-gereksinimleri %}) değil, doğruluğun ayrılmaz bir parçasıdır.
 
-**Öncelik ve kesme (*preemption*).** Görevlere öncelik atanır; daha öncelikli bir görev hazır olduğunda, çalışan düşük öncelikli görev anında durdurulup yerini ona bırakır. Hangi görevin hangi öncelikte ne zaman çalışacağını belirleyen kurala **zamanlama algoritması** denir. İki klasik yaklaşım: **RMS** (*Rate-Monotonic Scheduling*) — daha sık tekrarlanan görev daha yüksek önceliklidir; ve **EDF** (*Earliest Deadline First*) — deadline'ı en yakın olan görev önce çalışır. (Bu algoritmaların matematiksel "zamanlanabilirlik" ispatları başlı başına bir konudur; burada sezgisel düzeyde bırakıyoruz.)
+**RTOS.** Masaüstü Linux ya da Windows verimi ve adilliği önceler; bir görevin tam olarak ne zaman çalışacağını garanti etmez. Bir gerçek zamanlı işletim sistemi (FreeRTOS, VxWorks, QNX, Zephyr, ya da `PREEMPT_RT` yamalı Linux) ise öngörülebilirliği öne koyar: en yüksek öncelikli görevin sınırlı ve bilinen bir süre içinde işlemciye kavuşacağını taahhüt eder.
 
-### İşler Ters Gittiğinde: Öncelik Tersinmesi
+**Zamanlama.** Görevlere öncelik verilir; öncelikli bir görev hazır olunca, çalışan düşük öncelikli görev anında durdurulur (*preemption*). Hangi görevin ne zaman çalışacağına karar veren kurala zamanlama algoritması denir. İki klasiği: RMS (*Rate-Monotonic Scheduling*), daha sık tekrarlanan görevi daha öncelikli sayar; EDF (*Earliest Deadline First*), deadline'ı en yakın olanı önce çalıştırır. Bu algoritmaların matematiksel "zamanlanabilirlik" ispatları başlı başına bir konudur.
 
-Bu mekanizmaların ne kadar incelikli olduğunu anlatan en güzel hikâye, NASA'nın 1997'de Mars'a indirdiği **Mars Pathfinder** aracından gelir. Araç yüzeye iner inmez bilgisayarı tuhaf biçimde tekrar tekrar yeniden başlamaya başlar — milyonlarca kilometre öteden hata ayıklanması gereken bir kâbus.
+### Mars'taki Hata: Öncelik Tersinmesi
 
-Suçlu, gerçek zamanlı sistemlerin meşhur tuzağı **öncelik tersinmesidir** (*priority inversion*). Yüksek öncelikli bir görev, düşük öncelikli bir görevin elinde tuttuğu bir kaynağı (paylaşılan bir veri yolu) beklerken; araya giren *orta* öncelikli ama uzun süren bir görev, düşük öncelikli görevin çalışmasını engeller. Sonuçta yüksek öncelikli görev, kendisinden daha önemsiz bir göreve dolaylı yoldan takılıp kalır — öncelikler sanki tersine dönmüştür.
+Bu mekanizmaların ne kadar ince olduğunu en iyi anlatan hikâye, NASA'nın 1997'de Mars'a indirdiği Pathfinder aracından gelir. Araç yüzeye iner inmez bilgisayarı tekrar tekrar yeniden başlamaya başlar; milyonlarca kilometre öteden ayıklanması gereken bir kâbus.
 
-<div class="mermaid">
-sequenceDiagram
-    participant Y as Yüksek öncelik
-    participant O as Orta öncelik
-    participant D as Düşük öncelik
-    D->>D: kaynağı kilitler
-    Y->>Y: çalışmak ister, kaynağı bekler (bloke)
-    O->>O: araya girer, uzun süre CPU'yu tutar
-    Note over Y,D: Düşük öncelik kaynağı bırakamaz,<br/>Yüksek öncelik bekler → tersinme!
-    D->>D: nihayet çalışıp kaynağı bırakır
-    Y->>Y: ancak şimdi devam edebilir
-</div>
+Suçlu, gerçek zamanlı sistemlerin meşhur tuzağı **öncelik tersinmesidir** (*priority inversion*). Yüksek öncelikli bir görev, düşük öncelikli bir görevin tuttuğu paylaşılan bir kaynağı bekler. Tam o sırada araya giren orta öncelikli ve uzun süren bir görev, düşük öncelikli görevin çalışmasını engeller. Sonuçta yüksek öncelikli görev, kendisinden önemsiz bir göreve dolaylı yoldan takılıp kalır; öncelikler sanki tersine dönmüştür. Çözüm öncelik miras almadır (*priority inheritance*): paylaşılan kaynağı tutan düşük öncelikli görev, onu bırakana dek geçici olarak yüksek önceliğe terfi ettirilir. Pathfinder ekibi bu özelliği uzaktan etkinleştirip aracı kurtardı.
 
-Çözüm zarif bir kalıptır: **öncelik miras alma** (*priority inheritance*). Düşük öncelikli görev, yüksek öncelikli bir görevin beklediği bir kaynağı tutuyorsa, o kaynağı bırakana dek geçici olarak yüksek önceliğe "terfi" ettirilir; böylece araya orta öncelikli görevler giremez. Pathfinder ekibi, işletim sistemindeki bu özelliği uzaktan etkinleştirerek aracı kurtardı. Hikâyenin dersi nettir: gerçek zamanlı sistemlerde hatalar çoğu zaman tek tek bileşenlerin içinde değil, [bileşenlerin paylaştığı kaynaklarda ve aralarındaki etkileşimde]({% post_url 2026-06-04-coupling-dengesi %}) saklanır.
+Pathfinder'ın hatırlattığı şey şu: gerçek zamanlı sistemlerde hatalar çoğu zaman bileşenlerin içinde değil, [paylaştıkları kaynaklarda ve aralarındaki etkileşimde]({% post_url 2026-06-04-coupling-dengesi %}) saklanır.
 
 ---
 
-## Peki, Başka Gerçek Zamanlı Sistem Türleri Var mı?
+## Tek Eksen Değil
 
-Buraya kadar gördüğümüz hard/firm/soft/best-effort/none ayrımı, sistemleri **tek bir eksende** sıralar: *bir deadline kaçırılırsa ne olur?* Ama bu, gerçek zamanlı sistemleri sınıflandırmanın tek yolu değildir. Aynı sistem, birbirinden bağımsız başka eksenlerde de etiketlenir. İşte başlıcaları:
-
-### Zaman-Tetiklemeli mi, Olay-Tetiklemeli mi?
-
-Hermann Kopetz'in klasik ayrımıdır. **Zaman-tetiklemeli** (*time-triggered*) bir sistemde her şey, önceden belirlenmiş küresel bir zaman çizelgesine göre olur: "her 10 ms'de bir şu sensörü oku, şu çıkışı güncelle." Olaylar değil, saat yönetir; bu da öngörülebilirliği en üst düzeye çıkarır. **Olay-tetiklemeli** (*event-triggered*) bir sistemde ise işler, dış olaylar (bir kesme, bir mesaj) geldikçe tetiklenir — daha esnektir, ama yük arttığında öngörülebilirliği korumak zorlaşır. Güvenlik-kritik sistemler determinizm uğruna sıklıkla zaman-tetiklemeli tasarıma yönelir.
-
-### Görevler Nasıl Geliyor: Periyodik / Aperiyodik / Sporadik
-
-Bir başka eksen, görevlerin zaman içindeki gelme deseniyle ilgilidir:
-
-- **Periyodik** (*periodic*): Düzenli aralıklarla tekrarlayan görevler — "her 5 ms'de bir." Kontrol döngülerinin tipik halidir ve analiz etmesi en kolay olandır.
-- **Sporadik** (*sporadic*): Düzensiz gelen, ama iki gelişi arasında **bilinen bir asgari süre** garantisi olan görevler. Düzensizdir ama sınırlandırılabilir.
-- **Aperiyodik** (*aperiodic*): Tamamen düzensiz, asgari aralık garantisi olmayan görevler — analiz açısından en zoru.
-
-### Tek Düğümde mi, Dağıtık mı?
-
-Gerçek zamanlılık tek bir bilgisayarda bitmez. **Dağıtık gerçek zamanlı sistemlerde** garanti, ağ üzerinden de korunmak zorundadır — ki sıradan bir Ethernet ağı tam da best-effort olduğu için bu garantiyi vermez. Bu yüzden özel **gerçek zamanlı ağ** teknolojileri doğmuştur: otomotivde **CAN** ve **FlexRay**, aviyonikte **AFDX / ARINC 664**, ve hem zaman-tetiklemeli garantiyi hem standart Ethernet'i birleştiren **TTEthernet** ile **TSN** (*Time-Sensitive Networking*, IEEE 802.1). Bu ağlar paketlerin yalnızca ulaşmasını değil, *zamanında* ulaşmasını da güvence altına alır.
-
-### Karışık Kritiklik (Mixed-Criticality)
-
-Modern bir eğilim, farklı kritiklikteki görevlerin **aynı donanımı paylaşmasıdır**: aynı işlemcide hem hayati bir hard görev, hem de önemsiz bir best-effort görev koşar. Buradaki zorluk, önemsiz görevin hiçbir koşulda hayati görevin zamanlamasını bozamayacağını garanti etmektir. Aviyonikte bunun çözümü **ARINC 653** standardının getirdiği **zaman ve uzay bölümlemesidir** (*time and space partitioning*): her uygulamaya, başkalarının taşamayacağı kendi zaman dilimi ve kendi bellek alanı ayrılır. Böylece düşük kritikli bir yazılımdaki bir hata, yüksek kritikli komşusuna sıçrayamaz. Bu, [emniyet-kritik yazılım]({% post_url 2026-04-05-misra-c-2025-ile-neler-degisti %}) disiplininin gerçek zamanlılıkla buluştuğu noktadır.
-
-### Reaktif / Senkron Sistemler
-
-Bir de gerçek zamanlı yazılımı baştan "zaman doğru olacak şekilde" yazmaya çalışan diller vardır: **senkron diller** (*synchronous languages*) — Esterel, Lustre ve onun endüstriyel hali **SCADE**. Bu diller, programın deterministik zamanlama davranışını matematiksel olarak kanıtlanabilir kılar ve aviyonik gibi alanlarda kontrol yazılımı üretmekte kullanılır.
-
-### Bir de "Sahte" Gerçek Zamanlılık
-
-Son olarak, günlük dilde "real-time" kelimesi çok savrukça kullanılır: "real-time analytics", "gerçek zamanlı kontrol paneli", "canlı bildirim"... Bunların neredeyse tamamı, bu yazıdaki mühendislik anlamıyla **soft** ya da **best-effort** sistemlerdir. Birkaç saniyelik gecikme kimseyi incitmez. Gerçek bir hard gerçek zamanlı sistemden bahsederken kastedilen şey, deadline kaçırmanın bedelinin **ölçülebilir bir felaket** olduğu, milisaniyelerin sayıldığı dünyadır.
+Hard/firm/soft ayrımı sistemleri tek bir eksende dizer: deadline kaçarsa ne olur? Oysa gerçek zamanlı sistemler başka eksenlerde de ayrışır. Görevler saatin yönettiği önceden belirli bir çizelgeye göre mi tetikleniyor (zaman-tetiklemeli, *time-triggered*), yoksa dış olaylar geldikçe mi (olay-tetiklemeli)? Güvenlik-kritik tasarım, öngörülebilirlik uğruna çoğu zaman ilkini seçer. Garanti tek bir bilgisayarda mı kalıyor, yoksa ağ üzerinden mi taşınıyor? Sıradan Ethernet best-effort olduğundan, otomotivde CAN ve FlexRay, aviyonikte AFDX/ARINC 664, yeni sistemlerde TSN gibi gerçek zamanlı ağlar bu yükü üstlenir. Bir de modern eğilim: farklı kritiklikteki görevleri aynı donanımda koşturmak (*mixed-criticality*). Aviyonikte bunun çözümü ARINC 653'ün getirdiği zaman ve uzay bölümlemesidir; önemsiz bir görevdeki hata, hayati komşusuna sıçrayamasın diye. Bu, [emniyet-kritik yazılım]({% post_url 2026-04-05-misra-c-2025-ile-neler-degisti %}) disiplininin gerçek zamanlılıkla buluştuğu noktadır.
 
 ---
 
 ## Sonuç
 
-Gerçek zamanlı sistemleri anlamanın anahtarı, baştaki o iki gecikmeyi hatırlamaktır: takılan video ile geç açılan hava yastığı. Sistemin "hızlı" olup olmadığı değil, **geç kaldığında ne olduğu** her şeyi belirler.
+İyi mühendis bir görevle karşılaştığında "bunu ne kadar hızlı yaparım?" diye değil, önce şunu sorar: bunun bir deadline'ı var mı, kaçırırsam ne olur? Felaket mi (hard), çöpe gidecek bir sonuç mu (firm), azalan bir değer mi (soft), yoksa hiçbir şey mi (none)? Cevap; işletim sistemini, zamanlamayı, ağı ve gereken titizliği belirler.
 
-Bu yüzden iyi mühendis, bir görevle karşılaştığında "bunu ne kadar hızlı yapabilirim?" diye değil, önce şunu sorar: *Bu işin bir deadline'ı var mı? Varsa, o deadline'ı kaçırırsam ne olur — felaket mi (hard), çöpe atılacak bir sonuç mu (firm), azalan bir değer mi (soft), yoksa hiçbir şey mi (none)?* Cevap, hangi işletim sistemini, hangi zamanlamayı, hangi ağı ve ne kadar titizlik gerektiğini belirler.
-
-Ve unutmayın: gerçek zamanlılık ortalamalarla değil, **en kötü durumla** ilgilenir. Bir sistemi gerçek zamanlı yapan şey, iyi günlerde ne kadar hızlı olduğu değil, en kötü gününde bile sözünü tutacağına dair verebildiği garantidir. Tıpkı [sistem mühendisliğinde]({% post_url 2026-05-26-sistem-muhendisligi-nedir %}) olduğu gibi, asıl mühendislik, ortalamanın değil, sınırların yönetilmesinde gizlidir.
+Bir uyarı da yerinde olur: günlük dilde "real-time analytics", "canlı pano", "anlık bildirim" diye geçen şeylerin neredeyse tamamı, bu mühendislik anlamıyla soft veya best-effort'tur; birkaç saniyelik gecikme kimseyi incitmez. Gerçek bir hard sistemde ise milisaniyeler sayılır ve deadline kaçırmanın bedeli ölçülebilir bir felakettir. Sonuçta gerçek zamanlılığı belirleyen şey, sistemin iyi günlerde ne kadar hızlı olduğu değil, en kötü gününde bile sözünü tutacağına dair verebildiği garantidir.
 
 ---
 
@@ -199,6 +121,4 @@ Ve unutmayın: gerçek zamanlılık ortalamalarla değil, **en kötü durumla** 
 - Hermann Kopetz — *Real-Time Systems: Design Principles for Distributed Embedded Applications* (Springer).
 - Mike Jones — ["What Really Happened on Mars?"](https://www.cs.cornell.edu/courses/cs614/1999sp/papers/pathfinder.html) (Mars Pathfinder öncelik tersinmesi olayı; Glenn Reeves'in anlatımına dayanır).
 - ARINC 653 — *Avionics Application Software Standard Interface* (zaman ve uzay bölümlemesi); genel bakış: [ARINC 653 (Wikipedia)](https://en.wikipedia.org/wiki/ARINC_653).
-- RTCA/EUROCAE — DO-178C / ED-12C, *Software Considerations in Airborne Systems and Equipment Certification* (2011).
 - The Linux Foundation — [Real-Time Linux (`PREEMPT_RT`)](https://wiki.linuxfoundation.org/realtime/start).
-- IEEE 802.1 — [Time-Sensitive Networking (TSN) Task Group](https://www.ieee802.org/1/pages/tsn.html).

--- a/_posts/2026-06-24-gercek-zamanli-sistemler-hard-soft-best-effort.md
+++ b/_posts/2026-06-24-gercek-zamanli-sistemler-hard-soft-best-effort.md
@@ -1,0 +1,204 @@
+---
+title: "Gerçek Zamanlı Sistemler: Hızlı Olmak ile Zamanında Olmak Aynı Şey Değildir"
+subtitle: "Real-Time Systems: Hard, Firm, Soft, Best-Effort and Beyond"
+background: "/img/posts/2.webp"
+date: '2026-06-24 09:00:00'
+layout: post
+lang: tr
+mermaid: true
+categories: [muhendislik]
+tags: [gercek-zamanli-sistemler, gomulu-sistemler, aviyonik]
+---
+
+İki "gecikme" düşünün. İlki: akşam dizinizi izlerken görüntü 200 milisaniye takılıyor, bir kare donuyor, sonra düzeliyor. Canınız sıkılır, belki söylenirsiniz, ama hayat devam eder. İkincisi: bir kaza anında hava yastığını ateşleyecek sinyal, olması gerekenden 50 milisaniye geç geliyor. Bu kez ortada can sıkıntısı yoktur; ortada bir trajedi vardır.
+
+İki olayda da sistem "geç kaldı". Ama birinde gecikmenin bedeli bir homurtu, diğerinde bir insan hayatı. İşte **gerçek zamanlı sistemler** (*real-time systems*) tam da bu farkın üzerine kurulur. Yaygın sanının aksine gerçek zamanlılık "ne kadar hızlı" sorusu değildir; "**ne zaman**" sorusudur. Bir sonucun doğru olması yetmez — *zamanında* da olmak zorundadır. Geç gelen doğru cevap, çoğu zaman yanlış cevaptır.
+
+Bu yazıda önce "gerçek zamanlı" kelimesinin en çok yanlış anlaşılan yanını netleştireceğiz; sonra bir deadline kaçırıldığında ne olduğuna göre sistemleri bir spektruma yerleştireceğiz — **hard, firm, soft, best-effort** ve **none**. Ardından bir sistemi gerçek zamanlı yapan şeyin ne olduğuna ve bunun pratikte nasıl sağlandığına bakacağız. En sonunda da bu beşli spektrumun *tek* sınıflandırma ekseni olmadığını, gerçek zamanlı sistemlerin başka hangi açılardan ayrıştığını göreceğiz.
+
+---
+
+## "Gerçek Zamanlı" Hızlı Demek Değildir
+
+En baştan bir yanılgıyı dağıtalım: gerçek zamanlı, hızlı demek değildir. Saniyede milyarlarca işlem yapan bir sunucu gerçek zamanlı olmayabilir; saniyede yalnızca yüz işlem yapan mütevazı bir mikrodenetleyici ise kusursuz biçimde gerçek zamanlı olabilir.
+
+Aradaki fark **determinizmdir** (*determinism*) — yani öngörülebilirlik. Gerçek zamanlı bir sistemde önemli olan, bir işin *ortalama* ne kadar sürdüğü değil, **en kötü ihtimalle** ne kadar süreceğinin garanti altında olmasıdır. Bir işlem bazen 1 milisaniyede, bazen 2 milisaniyede, ama nadiren de olsa 100 milisaniyede bitiyorsa, ortalaması ne kadar parlak olursa olsun o sistem güvenilmezdir. Çünkü gerçek zamanlı dünyada sizi vuran şey ortalama değil, o ender görülen en kötü andır.
+
+Bu yüzden sözlüğümüze üç kavram girer:
+
+- **Deadline (son teslim anı):** Bir işin tamamlanmış olması gereken zaman sınırı. Gerçek zamanlılığın kalbidir.
+- **Gecikme (*latency*):** Bir olayın (bir sensör tetiklemesi, bir kesme) gerçekleşmesi ile sistemin ona yanıt vermesi arasında geçen süre.
+- **Seğirme (*jitter*):** Bu gecikmenin ölçümden ölçüme ne kadar değiştiği. Her döngüde tam tamına 10 ms'de yanıt veren bir sistem düşük seğirmelidir; bazen 8 bazen 14 ms'de yanıt veren sistem ise yüksek seğirmelidir — ve gerçek zamanlı tasarımda seğirme çoğu zaman ham hızdan daha kıymetlidir.
+
+Özetle: gerçek zamanlı bir sistem, "olabildiğince hızlı" çalışan değil, "**her zaman söz verdiği süre içinde**" çalışan sistemdir.
+
+---
+
+## Anahtar Fikir: Değerin Zamanla Değişmesi
+
+Sistemleri sınıflandıran zarif fikir şudur: bir sonucun değeri zamanla nasıl değişir? Bir işi deadline'ından *önce* bitirirseniz tam değeri alırsınız. Peki ya deadline kaçarsa? İşte cevabın şekli, sistemin hangi sınıfa girdiğini belirler.
+
+- Kimi sistemde deadline geçtiği an değer **uçuruma düşer**: sonuç yalnızca değersiz olmakla kalmaz, aktif olarak zarar verir.
+- Kimisinde değer aniden **sıfıra iner**: geç gelen sonuç işe yaramaz, ama en azından zararı da yoktur.
+- Kimisinde değer **kademeli olarak azalır**: geç gelir, biraz değer kaybeder, ama hâlâ bir işe yarar.
+- Kimisinde ise deadline diye keskin bir çizgi zaten yoktur; sadece "ne kadar erken, o kadar iyi" geçerlidir.
+
+Bu "değer fonksiyonunun" şekli, aşağıdaki beş sınıfı birbirinden ayıran asıl ölçüttür. Şimdi spektrumu en katısından en gevşeğine doğru gezelim.
+
+---
+
+## Spektrum: Hard, Firm, Soft, Best-Effort, None
+
+<div class="mermaid">
+flowchart LR
+    A["Hard<br/>kaçarsa felaket"] --> B["Firm<br/>geç = değersiz"] --> C["Soft<br/>geç = değer kaybı"] --> D["Best-effort<br/>garanti yok"] --> E["None<br/>zaman önemsiz"]
+    style A fill:#f6c1c1,stroke:#c0392b,stroke-width:2px
+    style B fill:#f6d8c1,stroke:#cb6b2b,stroke-width:2px
+    style C fill:#f6edc1,stroke:#b39a2b,stroke-width:2px
+    style D fill:#d9e8f5,stroke:#3d6fa5,stroke-width:2px
+    style E fill:#cfe8cf,stroke:#2e7d32,stroke-width:2px
+</div>
+
+Soldan sağa gidildikçe zaman kısıtının sertliği azalır, esneklik artar. Önce her birini tek tek görelim, sonra hepsini bir tabloda toplayalım.
+
+### Hard (Katı) Gerçek Zamanlı
+
+En tavizsiz uçtur. Bir tek deadline kaçırmak bile sistemin tümden başarısız sayılması demektir; sonuç çoğu zaman felakettir — maddi hasar, yaralanma, ölüm. Burada "geç gelen doğru cevap" yalnızca yararsız değil, tehlikelidir.
+
+Klasik örnekler güvenlik-kritik dünyadan gelir: bir uçağın **uçuş kontrol bilgisayarı**, otomobilin **hava yastığı** ve **ABS** (kilitlenmeyi önleyen fren) denetleyicisi, bir **kalp pili**, nükleer santralin acil kapatma sistemi. Bu sistemlerin doğruluğu yalnızca "ne hesapladığına" değil, "**tam olarak ne zaman** hesapladığına" bağlıdır. Hava yastığı milisaniyeler içinde açılmazsa hiç açılmamış gibidir.
+
+### Firm (Sıkı) Gerçek Zamanlı
+
+Bir adım gevşemiştir. Deadline kaçırılırsa sonuç **değersizdir** — atılır, kullanılmaz — ama bu, sistemi yıkmaz. Hard ile farkı şudur: gecikmiş sonucun bedeli sıfırdır, *negatif* değil. Üstelik firm sistemler ara sıra deadline kaçırmaya tahammül edebilir; yeter ki bu sık olmasın.
+
+Örneğin bir endüstriyel üretim hattında, robot kolu doğru anı kaçırırsa o parça ıskartaya çıkar; üzücüdür ama fabrika patlamaz, bir sonraki parçaya geçilir. Benzer biçimde geç hesaplanmış bir borsa emri ya da zamanı geçmiş bir video karesi: işe yaramaz, en doğrusu onu hiç göstermemektir.
+
+### Soft (Esnek) Gerçek Zamanlı
+
+Burada deadline keskin bir uçurum değil, yumuşak bir yokuştur. Deadline kaçtığında sonuç hâlâ bir **değer taşır**, sadece geciktikçe bu değer azalır. Amaç deadline'a "her zaman" değil, "çoğunlukla" uymak ve kalite ile gecikme arasında makul bir denge tutturmaktır.
+
+En tanıdık örnekler günlük hayatımızdan: **video/ses akışı** (bir kare biraz geç gelse de izleyici çoğu zaman fark etmez), **VoIP/görüntülü görüşme**, çevrimiçi **oyunlar**, ve genel olarak bir uygulamanın **arayüz tepkiselliği**. Bir butona bastığınızda 100 ms yerine 150 ms'de yanıt almak rahatsız edicidir ama yıkıcı değildir.
+
+### Best-Effort (Elden Geldiğince)
+
+Artık katı bir deadline garantisi yoktur. Sistem "elinden gelenin en iyisini" yapar: kaynakları olabildiğince verimli paylaştırır, ortalama tepkiselliği ve verimi (*throughput*) yüksek tutmaya çalışır, ama hiçbir tek isteğin belirli bir süre içinde biteceğine **söz vermez**.
+
+İnternetin temel teslim modeli budur (*best-effort delivery*): paketler genellikle hızlı ulaşır, ama hiçbir zaman garanti yoktur. Bir **web sunucusunun** istekleri yanıtlaması, genel amaçlı bir işletim sisteminin süreçleri zamanlaması da böyledir — hedef "adil ve hızlı", ama "garantili" değil.
+
+### None (Gerçek Zamanlı Olmayan)
+
+En gevşek uç. Zamanlama, doğruluğun bir parçası bile değildir. İş ne zaman biterse bitsin, sonuç aynı ölçüde geçerlidir; tek dert genel olarak işin makul bir sürede tamamlanmasıdır.
+
+Gece çalışan **toplu yedekleme** işleri, ay sonu **rapor üretimi**, çevrimdışı veri analizleri, bir derleyicinin kodu derlemesi... Bunlar bir dakika erken ya da geç bitsin, kimsenin umurunda değildir. Burada "deadline" kavramı mühendislik anlamında yoktur.
+
+### Hepsi Bir Arada
+
+| Sınıf | Deadline kaçarsa | Tipik örnek |
+|---|---|---|
+| **Hard** | Felaket; sonuç zararlı | Uçuş kontrol, hava yastığı, kalp pili, ABS |
+| **Firm** | Sonuç değersiz (ama zararsız), atılır | Endüstriyel üretim adımı, geç video karesi |
+| **Soft** | Sonucun değeri kademeli azalır | Video/ses akışı, VoIP, oyun, arayüz |
+| **Best-effort** | Garanti yok; "elinden geleni yap" | Web sunucusu, internet paket teslimi, genel OS zamanlama |
+| **None** | Önemli değil; zamanlama doğruluğun parçası değil | Gece yedekleme, çevrimdışı rapor, derleme |
+
+Önemli bir not: Bu sınıflar bütün bir cihazı değil, **tek tek görevleri** etiketler. Tek bir akıllı telefonun içinde aynı anda hard (modem/radyo zamanlaması), soft (video oynatma) ve none (arka planda fotoğraf yedekleme) görevleri yaşar. Mesele "bu sistem hangi sınıf?" değil, "bu *görevin* deadline'ı kaçarsa ne olur?" sorusudur.
+
+---
+
+## Bir Sistemi Gerçek Zamanlı Yapan Nedir?
+
+Madem hız değil, peki nedir? Tek kelimeyle: **garanti**. Gerçek zamanlı bir sistem, en kötü senaryoda bile deadline'ına uyacağını *önceden kanıtlayabilen* sistemdir. Bu güvence birkaç temel kavrama dayanır:
+
+- **WCET (En Kötü Durum Yürütme Süresi, *Worst-Case Execution Time*):** Bir görevin tamamlanmasının *en fazla* ne kadar süreceği. Gerçek zamanlı mühendis ortalama süreyle değil, bu en kötü değerle çalışır; çünkü garanti ancak en kötü duruma göre verilebilir. Bu yüzden çoğu zaman önbellek (*cache*), dallanma tahmini gibi "ortalamayı iyileştiren ama en kötü durumu öngörülemez kılan" mekanizmalar gerçek zamanlı tasarımda göze batar.
+- **Sınırlı gecikme:** Bir olaya yanıt süresinin bir üst sınırının olması ve bu sınırın asla aşılmaması.
+- **Düşük seğirme:** Yanıt süresinin ölçümden ölçüme neredeyse hiç değişmemesi. Özellikle kontrol döngülerinde, sürekli ama biraz oynak bir gecikme, daha büyük ama *sabit* bir gecikmeden çok daha kötü olabilir.
+
+Buradaki asıl zihniyet kayması şudur: gündelik yazılımda "çoğu zaman hızlı olsun, ara sıra yavaşlasa da olur" makbuldür. Gerçek zamanlı dünyada ise tam tersi geçerlidir — **biraz daha yavaş ama her seferinde aynı** olmak, ortalamada parlayıp ara sıra takılmaya yeğdir. Performans burada [fonksiyonel olmayan bir gereksinim]({% post_url 2022-07-11-fonksiyonel-olmayan-yazilim-gereksinimleri %}) olarak değil, doğruluğun ayrılmaz bir parçası olarak ele alınır.
+
+---
+
+## Bu Garanti Nasıl Sağlanır?
+
+Öngörülebilirlik kendiliğinden gelmez; tasarlanır. Birkaç temel araç:
+
+**Gerçek zamanlı işletim sistemi (RTOS).** Genel amaçlı bir işletim sistemi (masaüstü Linux, Windows) verimi ve adilliği önceler; bir görevin tam olarak ne zaman çalışacağını garanti etmez. Bir **RTOS** ise (FreeRTOS, VxWorks, QNX, Zephyr ya da gerçek zaman yaması uygulanmış Linux — `PREEMPT_RT`) öngörülebilirliği her şeyin önüne koyar: en yüksek öncelikli görevin, sınırlı ve bilinen bir süre içinde işlemciye kavuşacağını taahhüt eder.
+
+**Öncelik ve kesme (*preemption*).** Görevlere öncelik atanır; daha öncelikli bir görev hazır olduğunda, çalışan düşük öncelikli görev anında durdurulup yerini ona bırakır. Hangi görevin hangi öncelikte ne zaman çalışacağını belirleyen kurala **zamanlama algoritması** denir. İki klasik yaklaşım: **RMS** (*Rate-Monotonic Scheduling*) — daha sık tekrarlanan görev daha yüksek önceliklidir; ve **EDF** (*Earliest Deadline First*) — deadline'ı en yakın olan görev önce çalışır. (Bu algoritmaların matematiksel "zamanlanabilirlik" ispatları başlı başına bir konudur; burada sezgisel düzeyde bırakıyoruz.)
+
+### İşler Ters Gittiğinde: Öncelik Tersinmesi
+
+Bu mekanizmaların ne kadar incelikli olduğunu anlatan en güzel hikâye, NASA'nın 1997'de Mars'a indirdiği **Mars Pathfinder** aracından gelir. Araç yüzeye iner inmez bilgisayarı tuhaf biçimde tekrar tekrar yeniden başlamaya başlar — milyonlarca kilometre öteden hata ayıklanması gereken bir kâbus.
+
+Suçlu, gerçek zamanlı sistemlerin meşhur tuzağı **öncelik tersinmesidir** (*priority inversion*). Yüksek öncelikli bir görev, düşük öncelikli bir görevin elinde tuttuğu bir kaynağı (paylaşılan bir veri yolu) beklerken; araya giren *orta* öncelikli ama uzun süren bir görev, düşük öncelikli görevin çalışmasını engeller. Sonuçta yüksek öncelikli görev, kendisinden daha önemsiz bir göreve dolaylı yoldan takılıp kalır — öncelikler sanki tersine dönmüştür.
+
+<div class="mermaid">
+sequenceDiagram
+    participant Y as Yüksek öncelik
+    participant O as Orta öncelik
+    participant D as Düşük öncelik
+    D->>D: kaynağı kilitler
+    Y->>Y: çalışmak ister, kaynağı bekler (bloke)
+    O->>O: araya girer, uzun süre CPU'yu tutar
+    Note over Y,D: Düşük öncelik kaynağı bırakamaz,<br/>Yüksek öncelik bekler → tersinme!
+    D->>D: nihayet çalışıp kaynağı bırakır
+    Y->>Y: ancak şimdi devam edebilir
+</div>
+
+Çözüm zarif bir kalıptır: **öncelik miras alma** (*priority inheritance*). Düşük öncelikli görev, yüksek öncelikli bir görevin beklediği bir kaynağı tutuyorsa, o kaynağı bırakana dek geçici olarak yüksek önceliğe "terfi" ettirilir; böylece araya orta öncelikli görevler giremez. Pathfinder ekibi, işletim sistemindeki bu özelliği uzaktan etkinleştirerek aracı kurtardı. Hikâyenin dersi nettir: gerçek zamanlı sistemlerde hatalar çoğu zaman tek tek bileşenlerin içinde değil, [bileşenlerin paylaştığı kaynaklarda ve aralarındaki etkileşimde]({% post_url 2026-06-04-coupling-dengesi %}) saklanır.
+
+---
+
+## Peki, Başka Gerçek Zamanlı Sistem Türleri Var mı?
+
+Buraya kadar gördüğümüz hard/firm/soft/best-effort/none ayrımı, sistemleri **tek bir eksende** sıralar: *bir deadline kaçırılırsa ne olur?* Ama bu, gerçek zamanlı sistemleri sınıflandırmanın tek yolu değildir. Aynı sistem, birbirinden bağımsız başka eksenlerde de etiketlenir. İşte başlıcaları:
+
+### Zaman-Tetiklemeli mi, Olay-Tetiklemeli mi?
+
+Hermann Kopetz'in klasik ayrımıdır. **Zaman-tetiklemeli** (*time-triggered*) bir sistemde her şey, önceden belirlenmiş küresel bir zaman çizelgesine göre olur: "her 10 ms'de bir şu sensörü oku, şu çıkışı güncelle." Olaylar değil, saat yönetir; bu da öngörülebilirliği en üst düzeye çıkarır. **Olay-tetiklemeli** (*event-triggered*) bir sistemde ise işler, dış olaylar (bir kesme, bir mesaj) geldikçe tetiklenir — daha esnektir, ama yük arttığında öngörülebilirliği korumak zorlaşır. Güvenlik-kritik sistemler determinizm uğruna sıklıkla zaman-tetiklemeli tasarıma yönelir.
+
+### Görevler Nasıl Geliyor: Periyodik / Aperiyodik / Sporadik
+
+Bir başka eksen, görevlerin zaman içindeki gelme deseniyle ilgilidir:
+
+- **Periyodik** (*periodic*): Düzenli aralıklarla tekrarlayan görevler — "her 5 ms'de bir." Kontrol döngülerinin tipik halidir ve analiz etmesi en kolay olandır.
+- **Sporadik** (*sporadic*): Düzensiz gelen, ama iki gelişi arasında **bilinen bir asgari süre** garantisi olan görevler. Düzensizdir ama sınırlandırılabilir.
+- **Aperiyodik** (*aperiodic*): Tamamen düzensiz, asgari aralık garantisi olmayan görevler — analiz açısından en zoru.
+
+### Tek Düğümde mi, Dağıtık mı?
+
+Gerçek zamanlılık tek bir bilgisayarda bitmez. **Dağıtık gerçek zamanlı sistemlerde** garanti, ağ üzerinden de korunmak zorundadır — ki sıradan bir Ethernet ağı tam da best-effort olduğu için bu garantiyi vermez. Bu yüzden özel **gerçek zamanlı ağ** teknolojileri doğmuştur: otomotivde **CAN** ve **FlexRay**, aviyonikte **AFDX / ARINC 664**, ve hem zaman-tetiklemeli garantiyi hem standart Ethernet'i birleştiren **TTEthernet** ile **TSN** (*Time-Sensitive Networking*, IEEE 802.1). Bu ağlar paketlerin yalnızca ulaşmasını değil, *zamanında* ulaşmasını da güvence altına alır.
+
+### Karışık Kritiklik (Mixed-Criticality)
+
+Modern bir eğilim, farklı kritiklikteki görevlerin **aynı donanımı paylaşmasıdır**: aynı işlemcide hem hayati bir hard görev, hem de önemsiz bir best-effort görev koşar. Buradaki zorluk, önemsiz görevin hiçbir koşulda hayati görevin zamanlamasını bozamayacağını garanti etmektir. Aviyonikte bunun çözümü **ARINC 653** standardının getirdiği **zaman ve uzay bölümlemesidir** (*time and space partitioning*): her uygulamaya, başkalarının taşamayacağı kendi zaman dilimi ve kendi bellek alanı ayrılır. Böylece düşük kritikli bir yazılımdaki bir hata, yüksek kritikli komşusuna sıçrayamaz. Bu, [emniyet-kritik yazılım]({% post_url 2026-04-05-misra-c-2025-ile-neler-degisti %}) disiplininin gerçek zamanlılıkla buluştuğu noktadır.
+
+### Reaktif / Senkron Sistemler
+
+Bir de gerçek zamanlı yazılımı baştan "zaman doğru olacak şekilde" yazmaya çalışan diller vardır: **senkron diller** (*synchronous languages*) — Esterel, Lustre ve onun endüstriyel hali **SCADE**. Bu diller, programın deterministik zamanlama davranışını matematiksel olarak kanıtlanabilir kılar ve aviyonik gibi alanlarda kontrol yazılımı üretmekte kullanılır.
+
+### Bir de "Sahte" Gerçek Zamanlılık
+
+Son olarak, günlük dilde "real-time" kelimesi çok savrukça kullanılır: "real-time analytics", "gerçek zamanlı kontrol paneli", "canlı bildirim"... Bunların neredeyse tamamı, bu yazıdaki mühendislik anlamıyla **soft** ya da **best-effort** sistemlerdir. Birkaç saniyelik gecikme kimseyi incitmez. Gerçek bir hard gerçek zamanlı sistemden bahsederken kastedilen şey, deadline kaçırmanın bedelinin **ölçülebilir bir felaket** olduğu, milisaniyelerin sayıldığı dünyadır.
+
+---
+
+## Sonuç
+
+Gerçek zamanlı sistemleri anlamanın anahtarı, baştaki o iki gecikmeyi hatırlamaktır: takılan video ile geç açılan hava yastığı. Sistemin "hızlı" olup olmadığı değil, **geç kaldığında ne olduğu** her şeyi belirler.
+
+Bu yüzden iyi mühendis, bir görevle karşılaştığında "bunu ne kadar hızlı yapabilirim?" diye değil, önce şunu sorar: *Bu işin bir deadline'ı var mı? Varsa, o deadline'ı kaçırırsam ne olur — felaket mi (hard), çöpe atılacak bir sonuç mu (firm), azalan bir değer mi (soft), yoksa hiçbir şey mi (none)?* Cevap, hangi işletim sistemini, hangi zamanlamayı, hangi ağı ve ne kadar titizlik gerektiğini belirler.
+
+Ve unutmayın: gerçek zamanlılık ortalamalarla değil, **en kötü durumla** ilgilenir. Bir sistemi gerçek zamanlı yapan şey, iyi günlerde ne kadar hızlı olduğu değil, en kötü gününde bile sözünü tutacağına dair verebildiği garantidir. Tıpkı [sistem mühendisliğinde]({% post_url 2026-05-26-sistem-muhendisligi-nedir %}) olduğu gibi, asıl mühendislik, ortalamanın değil, sınırların yönetilmesinde gizlidir.
+
+---
+
+**Kaynaklar:**
+
+- C. L. Liu, James W. Layland — "Scheduling Algorithms for Multiprogramming in a Hard-Real-Time Environment," *Journal of the ACM*, vol. 20, no. 1, 1973. DOI: 10.1145/321738.321743.
+- Giorgio C. Buttazzo — *Hard Real-Time Computing Systems: Predictable Scheduling Algorithms and Applications* (Springer).
+- Hermann Kopetz — *Real-Time Systems: Design Principles for Distributed Embedded Applications* (Springer).
+- Mike Jones — ["What Really Happened on Mars?"](https://www.cs.cornell.edu/courses/cs614/1999sp/papers/pathfinder.html) (Mars Pathfinder öncelik tersinmesi olayı; Glenn Reeves'in anlatımına dayanır).
+- ARINC 653 — *Avionics Application Software Standard Interface* (zaman ve uzay bölümlemesi); genel bakış: [ARINC 653 (Wikipedia)](https://en.wikipedia.org/wiki/ARINC_653).
+- RTCA/EUROCAE — DO-178C / ED-12C, *Software Considerations in Airborne Systems and Equipment Certification* (2011).
+- The Linux Foundation — [Real-Time Linux (`PREEMPT_RT`)](https://wiki.linuxfoundation.org/realtime/start).
+- IEEE 802.1 — [Time-Sensitive Networking (TSN) Task Group](https://www.ieee802.org/1/pages/tsn.html).

--- a/_posts/2026-06-25-gercek-zamanli-sistemler-hard-soft-best-effort.md
+++ b/_posts/2026-06-25-gercek-zamanli-sistemler-hard-soft-best-effort.md
@@ -1,6 +1,6 @@
 ---
 title: "Gerçek Zamanlı Sistemler: Hızlı Değil, Zamanında"
-subtitle: "Hard, Firm, Soft and Best-Effort Real-Time Systems"
+subtitle: "Hard, Firm, Soft and Non-Real-Time Systems"
 background: "/img/posts/2.webp"
 date: '2026-06-25 09:00:00'
 layout: post
@@ -12,15 +12,15 @@ tags: [gercek-zamanli-sistemler, gomulu-sistemler, aviyonik]
 
 Akşam dizi izlerken görüntü yarım saniye donar, sonra kendine gelir. Sinir olursunuz, geçer. Aynı yarım saniye, bir kaza anında hava yastığını ateşleyecek sinyalin gecikmesi olduğunda ise ortada sinir değil, bir trajedi vardır.
 
-İki olayda da sistem geç kaldı; ama birinde bedeli bir homurtu, diğerinde bir hayat. Gerçek zamanlı sistemler kavramı tam da bu farkın üzerine kuruludur. Yaygın sanının aksine mesele "ne kadar hızlı" değil, "ne zaman" sorusudur: bir sonucun doğru olması yetmez, zamanında da gelmesi gerekir. Geç gelen doğru cevap çoğu zaman yanlış cevaptır.
+İki olayda da sistem geç kaldı; ama birinde bedeli bir homurtu, diğerinde bir hayat. Gerçek zamanlı sistemler kavramı tam da bu farkın üzerine kuruludur. İşin teknik tanımı da bunu söyler: gerçek zamanlılık, bir sistemin **her bağımsız işlevi için tanımlanmış zaman kısıtına uyabilme kabiliyetidir.** Bir fonksiyonu doğru yerine getirmek kadar, onu istenen zaman çerçevesinde yerine getirmek de gerekir; gerçek zamanlılık bu ikincisini dert edinir. Geç gelen doğru cevap çoğu zaman yanlış cevaptır.
 
 ---
 
 ## Gerçek Zamanlı, Hızlı Demek Değil
 
-Önce en sık yapılan hatayı dağıtalım. Saniyede milyarlarca işlem yapan bir sunucu gerçek zamanlı olmayabilir; saniyede yüz işlem yapan ufak bir mikrodenetleyici kusursuz biçimde gerçek zamanlı olabilir. Fark hızda değil, **determinizmde** (öngörülebilirlik): bir işin ortalama ne kadar sürdüğü değil, en kötü ihtimalle ne kadar süreceğinin garanti altında olması.
+Önce en sık yapılan hatayı dağıtalım: gerçek zamanlı sistem; hızlı, çok hızlı, inanılmaz hızlı sistem demek **değildir.** Saniyede milyarlarca işlem yapan bir sunucu gerçek zamanlı olmayabilir; saniyede yüz işlem yapan ufak bir mikrodenetleyici kusursuz biçimde gerçek zamanlı olabilir.
 
-Bir işlem çoğu zaman 1 ms'de bitip nadiren 100 ms'ye çıkıyorsa, ortalaması ne kadar iyi olursa olsun o sistem güvenilmezdir. Çünkü sizi vuran şey ortalama değil, o ender görülen en kötü andır.
+Fark hızda değil, **determinizmde** (öngörülebilirlik). Bir durum ve giriş kümesine karşı sistemin doğru yanıtı doğru zaman çerçevesi içinde üretmesi ne kadar öngörülebilirse, sistem o kadar deterministiktir. Buradaki anahtar, ortalama değil **en kötü durumdur:** bir işlem çoğu zaman 1 ms'de bitip nadiren 100 ms'ye çıkıyorsa, ortalaması ne kadar iyi olursa olsun o sistem güvenilmezdir. Çünkü sizi vuran şey ortalama değil, o ender görülen en kötü andır.
 
 Üç kavram işin sözlüğünü oluşturur:
 
@@ -28,61 +28,65 @@ Bir işlem çoğu zaman 1 ms'de bitip nadiren 100 ms'ye çıkıyorsa, ortalamas�
 - **Gecikme** (*latency*): Bir olay ile sistemin ona verdiği yanıt arasındaki süre.
 - **Seğirme** (*jitter*): Bu gecikmenin ölçümden ölçüme ne kadar oynadığı. Her döngüde tam 10 ms'de yanıt veren bir sistem iyidir; bazen 8 bazen 14 ms diyen sistem kötüdür. Kontrol döngülerinde seğirme çoğu zaman ham hızdan daha kıymetlidir.
 
+Bir sistem bu öngörülebilirliği ne kadar çok talep ediyorsa, aşağıdaki sınıflandırmada o kadar katı uca düşer.
+
 ---
 
-## Spektrum: Hard, Firm, Soft, Best-Effort, None
+## Sınıflar: Mutlak, Katı, Esnek, Gerçek Zamanlı Olmayan
 
-Sistemleri sınıflandıran soru tektir: deadline kaçarsa sonucun değerine ne olur? Kiminde değer uçuruma düşer, kiminde sıfırlanır, kiminde yavaşça erir, kiminde de deadline diye keskin bir çizgi zaten yoktur. Beş sınıf bu cevaba göre dizilir.
+Sınıfları birbirinden ayıran soru tektir: bir yanıt tanımlı zamandan **sonra** gelirse ne olur? Cevap, hem sistemin gerçek zamanlılık sınıfını hem de ondan beklenen determinizm seviyesini belirler.
 
 <div class="mermaid">
 flowchart LR
-    A["Hard<br/>kaçarsa felaket"] --> B["Firm<br/>geç = değersiz"] --> C["Soft<br/>geç = değer kaybı"] --> D["Best-effort<br/>garanti yok"] --> E["None<br/>zaman önemsiz"]
+    A["Mutlak / Hard<br/>geç yanıt kabul edilemez"] --> B["Katı / Firm<br/>geç yanıt faydasız"] --> C["Esnek / Soft<br/>geç yanıt değer kaybeder"] --> D["Gerçek Zamanlı Olmayan<br/>zaman kısıtı yok"]
     style A fill:#f6c1c1,stroke:#c0392b,stroke-width:2px
     style B fill:#f6d8c1,stroke:#cb6b2b,stroke-width:2px
     style C fill:#f6edc1,stroke:#b39a2b,stroke-width:2px
-    style D fill:#d9e8f5,stroke:#3d6fa5,stroke-width:2px
-    style E fill:#cfe8cf,stroke:#2e7d32,stroke-width:2px
+    style D fill:#cfe8cf,stroke:#2e7d32,stroke-width:2px
 </div>
 
-Soldan sağa zaman kısıtının sertliği azalır.
+Soldan sağa zaman kısıtının sertliği azalır; ters yönde, sağdan sola talep edilen **determinizm seviyesi** artar. En yüksek öngörülebilirlik en solda, mutlak uçta gerekir.
 
-### Hard (Katı)
+### Mutlak (Hard) Gerçek Zamanlı
 
-En tavizsiz uç. Tek bir deadline kaçırmak bile sistemi tümden başarısız kılar ve sonuç çoğu zaman felakettir: maddi hasar, yaralanma, ölüm. Uçağın uçuş kontrol bilgisayarı, otomobilin hava yastığı ve ABS denetleyicisi, bir kalp pili, nükleer santralin acil kapatma sistemi... Bu sistemlerin doğruluğu "ne hesapladığına" değil, "tam olarak ne zaman hesapladığına" bağlıdır. Hava yastığı milisaniyeler içinde açılmazsa hiç açılmamış sayılır.
+En tavizsiz uç. Yanıtların hep tanımlı zamandan önce gelmesi gerekir; herhangi bir yanıtın geç gelmesi kabul edilemez ve bütün sistemi başarısız kılar. Burada "geç gelen doğru yanıt" yalnızca yararsız değil, tehlikelidir. En yüksek determinizm bu uçta talep edilir.
 
-### Firm (Sıkı)
+Tipik örnekler: otomotiv güvenlik sistemleri (ABS, hava yastığı, ESP), yaşam destek amaçlı tıbbi cihazlar (kalp pili, solunum destek sistemleri) ve insansız hava aracı (İHA) otopilotu. Hava yastığı milisaniyeler içinde açılmazsa hiç açılmamış sayılır.
 
-Bir adım gevşemiştir. Deadline kaçarsa sonuç değersizdir; atılır, kullanılmaz. Ama bu sistemi yıkmaz. Hard'dan farkı, gecikmiş sonucun bedelinin sıfır olması, negatif olmaması. Üretim hattında doğru anı kaçıran robot kolunun çıkardığı parça ıskartaya gider; üzücüdür ama fabrika patlamaz. Zamanı geçmiş bir borsa emri ya da geç kalmış bir video karesi de öyledir: en doğrusu onu hiç kullanmamaktır. Firm sistemler ara sıra deadline kaçırmaya tahammül eder, yeter ki bu sık olmasın.
+### Katı (Firm) Gerçek Zamanlı
 
-### Soft (Esnek)
+Bir adım gevşemiştir. Yanıt yalnızca nadiren tanımlı zamandan sonra gelebilir. Geç gelen yanıt artık faydasızdır, atılır; ama bu sistemi yıkmaz, etkisi hizmet kalitesinin düşmesidir. Mutlak uçtan farkı, gecikmiş yanıtın bedelinin sıfır olması, negatif olmamasıdır.
 
-Burada deadline keskin bir uçurum değil, yumuşak bir yokuştur. Sonuç geç gelse de hâlâ işe yarar, sadece geciktikçe değeri azalır. Hedef, deadline'a "her zaman" değil "çoğunlukla" uymaktır. Video ve ses akışı, VoIP, çevrimiçi oyunlar, bir uygulamanın arayüz tepkiselliği... Bir butona bastığınızda 100 yerine 150 ms'de yanıt almak rahatsız edicidir ama yıkıcı değildir.
+Tipik örnekler: insansız kara aracı otopilotu, insansız seri üretim tezgâhları ve robotik otomasyon. Aynı otopilotun havada mutlak, karada katı olması anlamlıdır: karadaki araç durdurulabilir, geç gelen bir komutun bedeli genellikle ölümcül değildir.
 
-### Best-Effort (Elden Geldiğince)
+### Esnek (Soft) Gerçek Zamanlı
 
-Artık katı bir deadline garantisi yoktur. Sistem elinden gelenin en iyisini yapar: kaynağı verimli paylaştırır, ortalama tepkiselliği ve verimi (*throughput*) yüksek tutmaya çalışır, ama hiçbir tek isteğin belirli bir süre içinde biteceğine söz vermez. İnternetin teslim modeli (*best-effort delivery*) tam böyledir. Bir web sunucusunun istekleri karşılaması veya genel amaçlı bir işletim sisteminin süreçleri zamanlaması da aynı kategoridedir: hedef "adil ve hızlı", ama "garantili" değil.
+Burada deadline keskin bir uçurum değil, yumuşak bir yokuştur. Yanıtların gecikmesi daha sık görülür; geç gelen yanıt hâlâ işe yarar, ama tanımlı zamandan uzaklaştıkça faydası azalır. Etkisi yine hizmet kalitesinin düşmesidir.
 
-### None (Gerçek Zamanlı Olmayan)
+Tipik örnekler: sesli/görüntülü bilgi ve eğlence akış sistemleri (TV, radyo, video oyunları), iletişim sistemleri (telefon, telekonferans, görüntülü görüşme) ve konfora dönük ev otomasyonu. Bir görüntülü görüşmede karenin biraz geç gelmesi rahatsız edicidir ama yıkıcı değildir.
 
-En gevşek uç. Zamanlama, doğruluğun bir parçası bile değildir. İş ne zaman biterse bitsin sonuç aynı ölçüde geçerlidir. Gece çalışan toplu yedeklemeler, ay sonu raporları, çevrimdışı veri analizleri, bir derleyicinin kodu derlemesi... Bunların mühendislik anlamında bir deadline'ı yoktur.
+### Gerçek Zamanlı Olmayan (Non Real-time)
+
+En gevşek uç. Yanıtlar için tanımlı bir zaman yoktur; yanıt ne zaman gelirse gelsin faydalıdır ve sistemin hizmet kalitesi yanıt sürelerinden etkilenmez.
+
+Tipik örnekler: ödeme sistemleri (POS cihazları), endüstriyel otomasyon izleme sistemleri ve yığın (*batch*) işlem sistemleri (rapor/veri/kayıt üretimi, çevrimdışı sinyal analizi). Bunların mühendislik anlamında bir deadline'ı yoktur.
 
 ### Hepsi Bir Arada
 
-| Sınıf | Deadline kaçarsa | Tipik örnek |
+| Sınıf | Geç yanıt gelirse | Tipik örnek |
 |---|---|---|
-| **Hard** | Felaket; sonuç zararlı | Uçuş kontrol, hava yastığı, kalp pili, ABS |
-| **Firm** | Sonuç değersiz (ama zararsız), atılır | Üretim adımı, geç video karesi |
-| **Soft** | Değer kademeli azalır | Video/ses akışı, VoIP, oyun, arayüz |
-| **Best-effort** | Garanti yok; "elinden geleni yap" | Web sunucusu, internet paket teslimi, genel OS zamanlama |
-| **None** | Önemli değil | Gece yedekleme, çevrimdışı rapor, derleme |
+| **Mutlak (Hard)** | Kabul edilemez; bütün sistem başarısız olur | ABS, hava yastığı, ESP; kalp pili, solunum desteği; İHA otopilotu |
+| **Katı (Firm)** | Yanıt faydasız olur (atılır); hizmet kalitesi düşer | İnsansız kara aracı otopilotu; robotik üretim ve otomasyon |
+| **Esnek (Soft)** | Yanıtın faydası geciktikçe azalır; hizmet kalitesi düşer | TV/radyo/video akışı, oyunlar; telefon, telekonferans; ev otomasyonu |
+| **Gerçek Zamanlı Olmayan** | Önemsiz; zaman kısıtı tanımlı değil | POS/ödeme; endüstriyel izleme; yığın raporlama, sinyal analizi |
 
-Dikkat: bu sınıflar koca bir cihazı değil, tek tek **görevleri** etiketler. Bir akıllı telefonun içinde aynı anda hard (modem zamanlaması), soft (video oynatma) ve none (arka planda fotoğraf yedekleme) görevleri yaşar. Doğru soru "bu sistem hangi sınıf?" değil, "bu *görevin* deadline'ı kaçarsa ne olur?"dur.
+Önemli bir nokta: bu sınıflar koca bir cihazı bütün olarak değil, sistemin her **bağımsız işlevini** ayrı ayrı etiketler. Aynı İHA'nın içinde uçuş kontrolü mutlak (hard), telemetri akışı esnek (soft), uçuş sonrası kayıt indirme ise gerçek zamanlı olmayan bir işlev olabilir. Doğru soru "bu sistem hangi sınıf?" değil, "bu *işlevin* zaman kısıtı kaçarsa ne olur?"dur.
 
 ---
 
 ## Garantiyi Nasıl Veriyoruz?
 
-Madem hız değil, bir sistemi gerçek zamanlı yapan ne? Tek kelimeyle **garanti**: en kötü senaryoda bile deadline'a uyacağını önceden kanıtlayabilmek. Bu birkaç araca dayanır.
+Madem hız değil, bir işlevi gerçek zamanlı yapan ne? Tek kelimeyle **garanti**: en kötü senaryoda bile zaman kısıtına uyacağını önceden kanıtlayabilmek. Bu birkaç araca dayanır.
 
 **WCET** (en kötü durum yürütme süresi, *worst-case execution time*). Mühendis ortalamayla değil bu en kötü değerle çalışır; çünkü garanti ancak en kötü duruma göre verilebilir. Bu yüzden önbellek (*cache*) ve dallanma tahmini gibi "ortalamayı iyileştiren ama en kötü durumu öngörülemez kılan" mekanizmalar gerçek zamanlı tasarımda göze batar. Performans burada [fonksiyonel olmayan bir gereksinim]({% post_url 2022-07-11-fonksiyonel-olmayan-yazilim-gereksinimleri %}) değil, doğruluğun ayrılmaz bir parçasıdır.
 
@@ -102,15 +106,15 @@ Pathfinder'ın hatırlattığı şey şu: gerçek zamanlı sistemlerde hatalar �
 
 ## Tek Eksen Değil
 
-Hard/firm/soft ayrımı sistemleri tek bir eksende dizer: deadline kaçarsa ne olur? Oysa gerçek zamanlı sistemler başka eksenlerde de ayrışır. Görevler saatin yönettiği önceden belirli bir çizelgeye göre mi tetikleniyor (zaman-tetiklemeli, *time-triggered*), yoksa dış olaylar geldikçe mi (olay-tetiklemeli)? Güvenlik-kritik tasarım, öngörülebilirlik uğruna çoğu zaman ilkini seçer. Garanti tek bir bilgisayarda mı kalıyor, yoksa ağ üzerinden mi taşınıyor? Sıradan Ethernet best-effort olduğundan, otomotivde CAN ve FlexRay, aviyonikte AFDX/ARINC 664, yeni sistemlerde TSN gibi gerçek zamanlı ağlar bu yükü üstlenir. Bir de modern eğilim: farklı kritiklikteki görevleri aynı donanımda koşturmak (*mixed-criticality*). Aviyonikte bunun çözümü ARINC 653'ün getirdiği zaman ve uzay bölümlemesidir; önemsiz bir görevdeki hata, hayati komşusuna sıçrayamasın diye. Bu, [emniyet-kritik yazılım]({% post_url 2026-04-05-misra-c-2025-ile-neler-degisti %}) disiplininin gerçek zamanlılıkla buluştuğu noktadır.
+Mutlak/katı/esnek ayrımı sistemleri tek bir eksende dizer: zaman kısıtı kaçarsa ne olur? Oysa gerçek zamanlı sistemler başka eksenlerde de ayrışır. Görevler saatin yönettiği önceden belirli bir çizelgeye göre mi tetikleniyor (zaman-tetiklemeli, *time-triggered*), yoksa dış olaylar geldikçe mi (olay-tetiklemeli)? Güvenlik-kritik tasarım, öngörülebilirlik uğruna çoğu zaman ilkini seçer. Garanti tek bir bilgisayarda mı kalıyor, yoksa ağ üzerinden mi taşınıyor? Sıradan Ethernet "elinden geldiğince" (*best-effort*) çalıştığından, yani her paketi taşır ama zamanında teslimi garanti etmediğinden, otomotivde CAN ve FlexRay, aviyonikte AFDX/ARINC 664, yeni sistemlerde TSN gibi gerçek zamanlı ağlar bu yükü üstlenir. Bir de modern eğilim: farklı kritiklikteki işlevleri aynı donanımda koşturmak (*mixed-criticality*). Aviyonikte bunun çözümü ARINC 653'ün getirdiği zaman ve uzay bölümlemesidir; önemsiz bir işlevdeki hata, hayati komşusuna sıçrayamasın diye. Bu, [emniyet-kritik yazılım]({% post_url 2026-04-05-misra-c-2025-ile-neler-degisti %}) disiplininin gerçek zamanlılıkla buluştuğu noktadır.
 
 ---
 
 ## Sonuç
 
-İyi mühendis bir görevle karşılaştığında "bunu ne kadar hızlı yaparım?" diye değil, önce şunu sorar: bunun bir deadline'ı var mı, kaçırırsam ne olur? Felaket mi (hard), çöpe gidecek bir sonuç mu (firm), azalan bir değer mi (soft), yoksa hiçbir şey mi (none)? Cevap; işletim sistemini, zamanlamayı, ağı ve gereken titizliği belirler.
+İyi mühendis bir işlevle karşılaştığında "bunu ne kadar hızlı yaparım?" diye değil, önce şunu sorar: bunun tanımlı bir zaman kısıtı var mı, kaçırırsam ne olur? Felaket mi (mutlak/hard), faydasız bir yanıt mı (katı/firm), geciktikçe azalan bir fayda mı (esnek/soft), yoksa hiçbir şey mi (gerçek zamanlı olmayan)? Cevap; işletim sistemini, zamanlamayı, ağı ve gereken titizliği belirler.
 
-Bir uyarı da yerinde olur: günlük dilde "real-time analytics", "canlı pano", "anlık bildirim" diye geçen şeylerin neredeyse tamamı, bu mühendislik anlamıyla soft veya best-effort'tur; birkaç saniyelik gecikme kimseyi incitmez. Gerçek bir hard sistemde ise milisaniyeler sayılır ve deadline kaçırmanın bedeli ölçülebilir bir felakettir. Sonuçta gerçek zamanlılığı belirleyen şey, sistemin iyi günlerde ne kadar hızlı olduğu değil, en kötü gününde bile sözünü tutacağına dair verebildiği garantidir.
+Bir uyarı da yerinde olur: günlük dilde "real-time analytics", "canlı pano", "anlık bildirim" diye geçen şeylerin neredeyse tamamı, bu mühendislik anlamıyla en fazla esnek (soft) düzeydedir; birkaç saniyelik gecikme kimseyi incitmez. Gerçek bir mutlak (hard) sistemde ise milisaniyeler sayılır ve zaman kısıtını kaçırmanın bedeli ölçülebilir bir felakettir. Sonuçta gerçek zamanlılığı belirleyen şey, sistemin iyi günlerde ne kadar hızlı olduğu değil, en kötü gününde bile sözünü tutacağına dair verebildiği garantidir.
 
 ---
 

--- a/_posts/2026-06-25-gercek-zamanli-sistemler-hard-soft-best-effort.md
+++ b/_posts/2026-06-25-gercek-zamanli-sistemler-hard-soft-best-effort.md
@@ -2,7 +2,7 @@
 title: "Gerçek Zamanlı Sistemler: Hızlı Değil, Zamanında"
 subtitle: "Hard, Firm, Soft and Best-Effort Real-Time Systems"
 background: "/img/posts/2.webp"
-date: '2026-06-24 09:00:00'
+date: '2026-06-25 09:00:00'
 layout: post
 lang: tr
 mermaid: true


### PR DESCRIPTION
## Özet

Gerçek zamanlı (real-time) sistem ve yazılım konusunu anlatan yeni bir Türkçe blog yazısı ekler: `_posts/2026-06-24-gercek-zamanli-sistemler-hard-soft-best-effort.md`.

Yazı, gerçek zamanlılığın "hız" değil **determinizm ve deadline'a uyma** meselesi olduğu fikrinden yola çıkıp sistemleri bir deadline kaçırıldığında ne olduğuna göre **beşli bir spektruma** yerleştiriyor:

- **Hard** — kaçarsa felaket (uçuş kontrol, hava yastığı, kalp pili)
- **Firm** — geç sonuç değersiz ama zararsız
- **Soft** — geç sonucun değeri kademeli azalır (video/ses akışı, VoIP)
- **Best-effort** — garanti yok (web sunucusu, internet paket teslimi)
- **None** — zamanlama önemsiz (gece yedekleme, çevrimdışı rapor)

Ardından, kullanıcının ek sorusu üzerine, deadline sıkılığının **tek sınıflandırma ekseni olmadığını** anlatan bir bölüm: zaman-tetiklemeli vs olay-tetiklemeli (Kopetz), periyodik/aperiyodik/sporadik görevler, dağıtık gerçek zamanlı ağlar (AFDX/ARINC 664, CAN, FlexRay, TTEthernet, TSN), karışık kritiklik (ARINC 653 bölümleme) ve senkron diller (Esterel/Lustre/SCADE).

## İçerik öğeleri

- **Kavramsal ton** (istek üzerine): WCET, jitter, determinizm sezgisel düzeyde; ağır matematik/kod yok.
- 2 **Mermaid** diyagramı: sınıf spektrumu + Mars Pathfinder **öncelik tersinmesi** dizi diyagramı.
- 1 karşılaştırma **tablosu**.
- Mevcut yazılara iç linkler: sistem mühendisliği, coupling/DO-178C, MISRA C, fonksiyonel olmayan gereksinimler.
- Tam atıflı **Kaynaklar** bölümü (Liu & Layland 1973, Buttazzo, Kopetz, Pathfinder, ARINC 653, DO-178C, PREEMPT_RT, TSN).

## Doğrulama

- `bundle exec jekyll build` başarıyla tamamlandı (EXIT=0); tüm `{% post_url %}` linkleri çözümlendi.
- Üretilen HTML'de iç linkler, iki Mermaid bloğu ve tablo doğrulandı.
- Front matter mevcut yazılarla aynı kalıpta; hero görseli olarak kullanılmayan `/img/posts/2.webp` seçildi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MWUX6CAG5WKhsrqwBQ4qF

---
_Generated by [Claude Code](https://claude.ai/code/session_019MWUX6CAG5WKhsrqwBQ4qF)_