### PR TITLE
ci: bump actions/checkout to v6 in convert-to-webp workflow

### DIFF
--- a/.github/workflows/convert-to-webp.yml
+++ b/.github/workflows/convert-to-webp.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Bumps `actions/checkout@v4` → `actions/checkout@v6` in `.github/workflows/convert-to-webp.yml`.

## Why

GitHub Actions emitted a Node.js 20 deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/upload-artifact@v4`.

The WebP conversion workflow was the only one still pinned to `actions/checkout@v4` (it was added in #139, before the repo-wide upgrade to `@v6`). Every other workflow already uses `actions/checkout@v6`, so this just brings the file in line and resolves the directly-controllable half of the warning.

## Note on `actions/upload-artifact@v4`

This action is **not referenced directly anywhere** in the repo — it's a transitive dependency bundled inside a third-party action (e.g. `github/codeql-action`). It cannot be fixed by editing a `uses:` line here; GitHub auto-upgrades its runtime to Node.js 24 (which is exactly the "being forced to run on Node.js 24" message). It will clear once the upstream action ships a release with `upload-artifact@v5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cc9UDYB6GHZSD6pteFPBLh)_