### PR TITLE
Yeni yazı: MTBF Bir Ömür Değildir — 10⁻⁹ Hedefinin Aritmetiği

### DIFF
--- a/_posts/2026-08-19-mtbf-bir-omur-degildir.md
+++ b/_posts/2026-08-19-mtbf-bir-omur-degildir.md
@@ -1,0 +1,334 @@
+---
+title: "MTBF Bir Ömür Değildir: 10⁻⁹ Hedefinin Aritmetiği"
+subtitle: "MTBF Is Not a Lifetime: The Arithmetic Behind the 10⁻⁹ Objective"
+background: "/img/posts/2.webp"
+date: '2026-08-19 12:00:00'
+layout: post
+lang: tr
+mermaid: true
+categories: [aviyonik]
+tags: [emniyet-kritik, sistem-muhendisligi]
+---
+
+Bir tedarikçi datasheet'inde "MTBF: 250.000 saat" satırını gördüğünüzde aklınızdan ne geçiyor? Çoğu mühendisin ilk refleksi bölme yapmak: 250.000 saat, 28,5 yıl. "Demek ki bu kutu 28 yıl dayanıyor." Bu cümle yanlış. Yalnızca biraz yanlış da değil; hem sayının anlamı, hem ölçüsü, hem de mühendislik kararına etkisi bakımından yanlış.
+
+MTBF, güvenilirlik mühendisliğinin en çok kullanılan ve en çok yanlış anlaşılan sayısıdır. Aviyonikte bu yanlış anlama daha da pahalıya patlıyor, çünkü orada asıl hedef MTBF değil; uçuş saati başına $10^{-9}$ gibi bir olasılık. Bu iki sayı arasındaki köprüyü kuran şey, çoğu Türkçe kaynakta hiç geçmeyen bir çarpan: **maruz kalma süresi**.
+
+Bu yazıda önce MTBF'in matematiksel tanımını yerine oturtacağım, sonra dört yaygın yanılgıyı sayısal karşı örneklerle tek tek yıkacağım, ardından bileşen arıza oranından sertifikasyon hedefine giden aritmetiği türeteceğim. Bütün sayılar tekrar üretilebilir: her biri kapalı formdan hesaplandı, kritik olanlar sayısal integrasyonla veya tabloyla çapraz doğrulandı.
+
+---
+
+## Kısa bir tarihçe: 1965'te donmuş bir el kitabı
+
+Elektronik güvenilirlik tahmininin modern hikâyesi 1960'larda, ABD Savunma Bakanlığı'nın MIL-HDBK-217 el kitabıyla başlıyor. Fikir çekici derecede basitti: her bileşen tipi için bir taban arıza oranı tablosu ver, sonra kalite, ortam ve sıcaklık için $\pi$ (pi) çarpanlarıyla düzelt, hepsini topla, sistemin arıza oranını bul.
+
+El kitabının son revizyonu **MIL-HDBK-217F Notice 2** ve tarihi **28 Şubat 1995**. Yani bugün hâlâ ihalelerde şart koşulan bu doküman, Pentium'un piyasaya çıktığı yıllardan kalma bileşen verisiyle çalışıyor. Sonraki revizyon (217G) için çalışmalar başladı ama tamamlanmadı. Boşluğu ticari ve bölgesel metodolojiler doldurdu:
+
+| Metodoloji | Güncel sürüm | Kökeni / odağı |
+|---|---|---|
+| MIL-HDBK-217F | Notice 2, 1995 | ABD askerî; parça sayımı ve parça gerilimi yöntemleri |
+| 217Plus | 2015, Notice 1 | RIAC/Quanterion; süreç faktörlerini de modele katar |
+| FIDES Guide | 2022, Edition A | Fransız havacılık-savunma konsorsiyumu; misyon profili tabanlı |
+| IEC 61709 | Ed. 3.0, 2017 | IEC 61709:2011 + IEC TR 62380:2004 birleşimi; dönüşüm modelleri verir, taban oran vermez |
+| Telcordia SR-332 | Issue 4, 2016 | Telekom ekipmanı; saha verisiyle Bayesçi güncelleme |
+
+Bu tablodaki en önemli satır IEC 61709. Çünkü o, diğerlerinden farklı bir şey yapıyor: taban arıza oranı **vermiyor**, yalnızca bir çalışma koşulundan diğerine dönüştürme modelleri sunuyor. Bu, sektörün 25 yılda öğrendiği dersin itirafı gibi: taban oranları evrensel bir tablodan okumak çalışmıyor.
+
+Ne kadar çalışmadığını ABD Ulusal Araştırma Konseyi'nin 2015 tarihli *Reliability Growth: Enhancing Defense System Reliability* raporunun D ekinde görebilirsiniz. Rapor, tahmin edilen MTBF ile sahada gözlenen MTBF oranlarının vaka çalışmalarında 0,54 ile 12,20 arasında dağıldığını, bazı askerî sistemlerde bu oranın 218:1'e kadar çıktığını aktarıyor. 218 kat sapan bir tahmin, tahmin değildir.
+
+Eleştirilerin teknik özü, Pecht ve Nash'in 1988'de *IEEE Transactions on Reliability*'de yayımladığı çalışmadan bu yana değişmedi: sabit arıza oranı varsayımı, $\pi$ faktörlerinin birbirinden bağımsız kabul edilmesi, sıcaklığın tek bir durağan değere indirgenmesi ve sıcaklık *çevriminin* tamamen gözden kaçırılması.
+
+Bu eleştirilerin en can alıcısı ilki. Ona bakalım.
+
+---
+
+## MTBF neyin kısaltması değildir
+
+Güvenilirlik matematiğinin temel nesnesi MTBF değil, **hazard rate** (anlık arıza oranı) $h(t)$'dir: bir birimin $t$ anına kadar sağ kalmış olması koşuluyla, hemen sonraki birim zamanda arızalanma eğilimi. Güvenilirlik fonksiyonu bundan türer:
+
+$$
+R(t) = \exp\!\left(-\int_0^t h(u)\,\mathrm{d}u\right), \qquad
+\mathrm{MTTF} = \int_0^\infty R(t)\,\mathrm{d}t
+$$
+
+Sağdaki ifadeye dikkat edin: ortalama arıza süresi, güvenilirlik eğrisinin **altındaki alandır**. Belirli bir zamandaki güvenilirlik değil, tüm eğrinin özeti. Tek bir sayıya sıkıştırılmış bir fonksiyon.
+
+Şimdi kritik adım. Eğer ve **yalnızca eğer** $h(t) = \lambda$ sabitse:
+
+$$
+R(t) = e^{-\lambda t}, \qquad \mathrm{MTTF} = \frac{1}{\lambda}
+$$
+
+MTBF $= 1/\lambda$ eşitliği burada, bu varsayımın altında doğar. Sabit hazard rate, "bileşenin yaşı yoktur" demektir: bir yıl çalışmış kart ile kutudan yeni çıkmış kart, gelecek saat içinde aynı olasılıkla arızalanır. Üstel dağılımın *hafızasızlık* özelliği budur.
+
+Bu varsayım küvet eğrisinin yalnızca orta bölgesinde, erken arızalar (burn-in) elendikten sonra ve yıpranma (wear-out) başlamadan önce yaklaşık olarak geçerlidir. Elektrolitik kondansatörde, fanda, rölede, konnektörde geçerli değildir. LED'de, flash bellekte, güç MOSFET'inde geçerli değildir.
+
+<div class="mermaid">
+graph LR
+    A[Erken arizalar - azalan hazard rate] --> B[Faydali omur - sabit lambda]
+    B --> C[Yipranma - artan hazard rate]
+</div>
+
+Küvet eğrisinin üç bölgesinden yalnızca ortadakinde $h(t) \approx \lambda$ tutar; MTBF $= 1/\lambda$ eşitliği de yalnızca orada anlamlıdır.
+
+Ve burada yazının ilk somut sonucu geliyor: aynı MTBF'e sahip iki ürün, aynı riske sahip değildir.
+
+---
+
+## Yanılgı 1: MTBF bir ömür değildir
+
+En basit hâliyle gösterelim. MTBF'i 100.000 saat olan bir birim düşünün ve 10 yıllık sürekli bir görev tanımlayın. 10 yıl, yani 87.660 saat; bu da $\lambda t = 0{,}8766$ demek:
+
+$$
+R(10\ \text{yıl}) = e^{-0{,}8766} = 0{,}4162
+$$
+
+Yani bu birimin 10 yıl boyunca hiç arızalanmama olasılığı **%41,6**. Arızalanma olasılığı %58,4. "100.000 saat MTBF" ile "11,4 yıl dayanır" arasında sezginin kurduğu bağ tamamen kopuk: MTBF'e eşit süre kadar çalıştırdığınızda sağ kalma olasılığı $e^{-1} = 0{,}368$'dir. Herhangi bir MTBF için, herhangi bir birim için. Yani MTBF, birimlerin yaklaşık **üçte ikisinin** çoktan arızalanmış olduğu andır.
+
+Şimdi asıl ilginç kısım. Aynı MTTF'e (100.000 saat) sahip iki farklı dağılım kuralım: biri üstel ($\beta = 1$), diğeri Weibull $\beta = 3$ (tipik bir yıpranma davranışı). Weibull için $\mathrm{MTTF} = \eta\,\Gamma(1 + 1/\beta)$ olduğundan, $\beta = 3$ için $\eta$ = 111.985 saat seçilirse iki dağılımın MTTF'i birebir aynı olur.
+
+| Süre | $R(t)$, üstel ($\beta=1$) | $R(t)$, Weibull ($\beta=3$) |
+|---|---|---|
+| 1 yıl | 0,9161 | 0,9995 |
+| 5 yıl | 0,6451 | 0,9418 |
+| 10 yıl | 0,4162 | 0,6190 |
+| 15 yıl | 0,2685 | 0,1981 |
+
+İki ürünün datasheet'inde de "MTBF 100.000 saat" yazıyor. Beş yıllık bir görevde Weibull'lu ürün üstel olandan **%46 daha güvenilir**. On beş yıllık bir görevde ise **daha kötü** — eğriler kesişiyor. Tek bir sayıya bakarak bu iki ürün arasında seçim yapmak mümkün değil.
+
+Pratik sonuç: bir tedarikçiden MTBF istemek yerine **görev süreniz için $R(t)$** isteyin. Cevap veremiyorsa, verdiği MTBF sayısının arkasında bir dağılım modeli yok demektir.
+
+---
+
+## Yanılgı 2: Yedeklilik MTBF'i ikiye katlamaz
+
+İki özdeş kanal koyup "artık MTBF iki katı" demek, sahada duyduğum en yaygın ikinci hatadır. Türetelim. İki aktif kanal, sistem en az biri çalışırken ayakta (1oo2), onarım yok:
+
+$$
+R_{\text{sis}}(t) = 1 - \left(1 - e^{-\lambda t}\right)^2 = 2e^{-\lambda t} - e^{-2\lambda t}
+$$
+
+$$
+\mathrm{MTTF}_{\text{sis}} = \int_0^\infty \left(2e^{-\lambda t} - e^{-2\lambda t}\right)\mathrm{d}t
+= \frac{2}{\lambda} - \frac{1}{2\lambda} = \frac{3}{2\lambda}
+$$
+
+Yani iki kat değil, **1,5 kat**. Bir kanalın MTBF'i 10.000 saat ise, iki kanallı sistemin MTBF'i 20.000 değil 15.000 saattir. (Bunu $\lambda = 10^{-4}$ için sayısal integrasyonla doğruladım: 15.000,0 saat.) İkinci kanal, ilk kanal arızalandıktan sonra tek başına ve yedeksiz çalışmaya devam ettiği için beklenen katkısı yalnızca $1/(2\lambda)$ kadardır.
+
+Onarım eklediğimizde tablo tamamen değişir. Üç durumlu bir Markov zinciri kuralım: her iki kanal sağlam (0), bir kanal arızalı (1), her iki kanal arızalı (2, yutucu). Onarım oranı $\mu = 1/\mathrm{MTTR}$:
+
+<div class="mermaid">
+stateDiagram-v2
+    direction LR
+    S0: Iki kanal saglam
+    S1: Bir kanal arizali
+    S2: Sistem arizali
+    S0 --> S1: 2 lambda
+    S1 --> S2: lambda
+    S1 --> S0: mu
+</div>
+
+Yutucu duruma varış süresini yazalım. $T_0$ ve $T_1$, ilgili durumlardan başlayarak beklenen sistem arıza süreleri olsun:
+
+$$
+T_0 = \frac{1}{2\lambda} + T_1, \qquad
+T_1 = \frac{1}{\lambda + \mu} + \frac{\mu}{\lambda + \mu}\,T_0
+$$
+
+İkinciyi birincide yerine koyup $T_0$ için çözünce:
+
+$$
+\mathrm{MTTF}_{\text{sis}} = T_0 = \frac{3\lambda + \mu}{2\lambda^2}
+$$
+
+Buradaki $\lambda^2$ paydası her şeyi anlatıyor. $\lambda = 10^{-4}$ (tek kanal MTBF'i 10.000 saat) için:
+
+| MTTR | Sistem MTBF (saat) | Kabaca |
+|---|---|---|
+| 1 saat | $5{,}00 \times 10^{7}$ | ~5.700 yıl |
+| 8 saat | $6{,}27 \times 10^{6}$ | ~715 yıl |
+| 24 saat | $2{,}10 \times 10^{6}$ | ~239 yıl |
+| 168 saat (bir hafta) | $3{,}13 \times 10^{5}$ | ~36 yıl |
+
+Yedekliliğin değeri, kanal sayısından değil **onarım hızından** geliyor. Bir haftalık onarım süresiyle bir saatlik onarım süresi arasında 160 kat fark var — hiçbir donanım iyileştirmesi bu kaldıraca yaklaşamaz. Bakım konsepti bir lojistik detay değil, güvenilirlik tasarımının parçasıdır.
+
+Ve bu, uçakta çok daha keskin bir biçimde karşımıza çıkacak. Çünkü uçakta "onarım", uçuş sırasında olmaz.
+
+---
+
+## Yanılgı 3: 10⁻⁹ bir bileşen hedefi değildir
+
+Aviyonikte emniyet hedefleri arıza oranıyla değil, **uçuş saati başına ortalama olasılıkla** ifade edilir. FAA'in bu konudaki dokümanı olan AC 25.1309-1B, **30 Ağustos 2024**'te yayımlandı ve 1988 tarihli AC 25.1309-1A'yı iptal etti. Bu, alanda dikkat çekmesi gereken bir güncelleme: 2002'de dolaşıma giren ve yıllarca "Arsenal Draft" adıyla atıf alan 1B taslağı nihayet resmîleşti. İnternette bulacağınız Türkçe ve İngilizce kaynakların çok büyük kısmı hâlâ 1A'ya atıf yapıyor.
+
+Sınıflandırma tablosu tanıdık:
+
+| Arıza durumu sınıfı | Nitel terim | Uçuş saati başına ortalama olasılık |
+|---|---|---|
+| Katastrofik | Extremely Improbable | $\le 1 \times 10^{-9}$ |
+| Tehlikeli (Hazardous) | Extremely Remote | $\le 1 \times 10^{-7}$ |
+| Majör | Remote | $\le 1 \times 10^{-5}$ |
+| Minör | Probable | $> 1 \times 10^{-5}$ |
+
+$10^{-9}$ sayısı gökten inmedi. Kamuya açık gerekçelendirme şöyle işliyor: 1970'lerde tüm nedenler dahil kaza oranı milyon uçuş saatinde yaklaşık dört mertebesindeydi. Bunun yaklaşık %10'u sistem kaynaklı kabul edilirse, tüm sistemler için hedef $10^{-7}$/saat civarına iner. Tipik bir büyük uçakta katastrofik sonuca yol açabilecek arıza durumu sayısı kabaca 100 varsayılırsa, her bir arıza durumuna düşen pay $10^{-9}$/saat olur. Yani bu sayı fiziksel bir sabit değil, bir **bütçe paylaştırması**.
+
+Şimdi ölçek karşılaştırması yapalım. Güvenilirlikte kullanılan FIT birimi, $10^{9}$ saatte bir arıza demektir; yani **1 FIT $= 10^{-9}$/saat**. Katastrofik bir arıza durumunun bütçesi, tam olarak 1 FIT'lik bir olasılıktır.
+
+Tipik bir aviyonik LRU'da 2.000 civarında elektronik bileşen olduğunu ve bileşen başına ortalama 20 FIT düştüğünü varsayalım (temsilî sayılar). Kutunun toplam arıza oranı 40.000 FIT, yani $4 \times 10^{-5}$/saat; MTBF olarak 25.000 saat. Bu kutunun arıza oranı, katastrofik bütçenin **40.000 katı**. Tek bir dirençin arıza oranı bile çoğu zaman 1 FIT'in üzerindedir.
+
+Buradan çıkan sonuç sarsıcı olmalı: **hiçbir tekil (simplex) mimari, hiçbir bileşen kalitesiyle $10^{-9}$'a ulaşamaz.** O sayı bileşenlerden değil, mimariden gelir. Peki mimari onu nasıl üretir?
+
+---
+
+## Maruz kalma süresi: aradaki eksik çarpan
+
+İki bağımsız kanalın *ikisinin birden* arızalanmasını gerektiren bir arıza durumu düşünelim. Sezgi, olasılıkların çarpılacağını söyler: $\lambda_1 \lambda_2$. Ama bu boyutsal olarak yanlış — $[1/\text{saat}]^2$ birimli bir sayı, uçuş saati başına olasılık olamaz. Eksik olan çarpan zamandır ve hangi zaman olduğu tamamen mimariye bağlıdır.
+
+Kritik ayrım şu: iki arızadan biri **gizli** (latent) mi? Yani meydana geldiğinde mürettebata veya sisteme kendini gösteriyor mu, yoksa yalnızca periyodik bir testte mi yakalanıyor? Yedek bir kanal, yedek bir hidrolik pompa, bir güvenlik monitörü — bunlar tipik olarak gizli arıza adaylarıdır, çünkü asıl kanal çalıştığı sürece arızalı olduklarını kimse fark etmez.
+
+Gizli arızalı A birimini $T$ periyoduyla test ettiğimizi varsayalım (her testte kusursuz onarım). Rastgele bir uçuş anında A'nın **zaten arızalı olma** olasılığının ortalaması:
+
+$$
+\bar{P}_A = \frac{1}{T}\int_0^T \left(1 - e^{-\lambda_A t}\right)\mathrm{d}t
+= 1 - \frac{1 - e^{-\lambda_A T}}{\lambda_A T}
+\;\approx\; \frac{\lambda_A T}{2}
+$$
+
+Yaklaşım $\lambda_A T \ll 1$ rejiminde geçerli. Ne kadar geçerli olduğunu sayısal olarak kontrol ettim: $\lambda_A T = 0{,}005$ için yaklaşım hatası %0,17; $\lambda_A T = 0{,}05$ için %1,7; $\lambda_A T = 0{,}5$ için %17,3. Aviyonik ölçeklerde ($\lambda \sim 10^{-8}$, $T \sim 10^3$ saat) yaklaşım pratikte tamdır.
+
+Sistem arıza durumunun uçuş saati başına ortalama olasılığı, "A zaten arızalıyken B'nin de arızalanması" ile verilir:
+
+$$
+\bar{P}_{\text{olay}}\;/\text{saat} \;\approx\; \lambda_B \cdot \frac{\lambda_A T}{2}
+$$
+
+Şimdi bu formülü çalıştıralım. İki kanalın da 50 FIT olduğunu varsayalım ($\lambda = 5 \times 10^{-8}$/saat — iyi tasarlanmış bir kanal için makul bir mertebe):
+
+| Gizli arıza test aralığı $T$ | Ortalama olasılık / uçuş saati | $10^{-9}$ hedefine pay |
+|---|---|---|
+| 1 saat (her uçuş öncesi BIT) | $1{,}30 \times 10^{-15}$ | 767.000× |
+| 10 saat | $1{,}25 \times 10^{-14}$ | 80.000× |
+| 100 saat | $1{,}25 \times 10^{-13}$ | 8.000× |
+| 500 saat | $6{,}25 \times 10^{-13}$ | 1.600× |
+| 2.000 saat | $2{,}50 \times 10^{-12}$ | 400× |
+| 5.000 saat | $6{,}25 \times 10^{-12}$ | 160× |
+
+Tabloda okunması gereken şey şu: iki kanalı bağımsız kılmak olasılığı $10^{-8}$'den $10^{-15}$ mertebesine indiriyor — yedi mertebe. Ama test aralığı $T$, sonuca **doğrusal** olarak giriyor. Bakım aralığını 100 saatten 5.000 saate çıkarmak, olasılığı 50 kat kötüleştiriyor.
+
+Bu, mühendislik açısından son derece pratik bir sonuç: **gizli arızaların test aralığı, güvenilirlik bütçesinde donanım kalitesiyle aynı ligde bir tasarım değişkenidir.** Bileşen kalitesini yükselterek $\lambda$'yı iki kat iyileştirmek aylar sürer ve pahalıdır; aynı kazancı, o gizli arızayı yakalayan bir BIT testini uçuş öncesi kontrole taşıyarak elde edebilirsiniz. Gizli arızaların ve maruz kalma sürelerinin ARP4761 ailesindeki emniyet değerlendirme yönteminin ayrılmaz parçası olmasının nedeni budur. Aynı nedenle, sertifikasyon tarafında bir bakım aralığını uzatmak nadiren "sadece lojistik" bir karardır: emniyet analizini geçersiz kılabilir.
+
+Bir uyarı: yukarıdaki türev, iki arızanın bağımsız olduğu, testin kusursuz olduğu ve $\lambda T \ll 1$ olduğu varsayımlarına dayanıyor. Her iki arızanın da gizli olduğu, testlerin farklı periyotlarda yapıldığı veya ortak sebep (common cause) bulunduğu durumlarda çarpan değişir; kullanılan emniyet değerlendirme yöntemi bu konfigürasyonları ayrı ayrı ele almak zorundadır. Buradaki amaç kapalı formu ezberletmek değil, $T$'nin neden doğrudan bir çarpan olduğunu göstermek.
+
+---
+
+## Yanılgı 4: Yazılımın MTBF'i yoktur
+
+Zaman zaman şartnamelerde "yazılım MTBF'i: 50.000 saat" gibi maddelerle karşılaşılıyor. Bu madde anlamsızdır ve onu yazan taraf genellikle bunu bilmez.
+
+MTBF, **rastgele** arızalar için tanımlıdır: fiziksel bir bileşen, üretim toleransları ve çevresel gerilim altında stokastik bir zamanda bozulur. Yazılım bozulmaz. Yazılımdaki hata, ilk derlemeden itibaren oradadır; belirli bir girdi kümesi o kod yoluna ulaştığında ortaya çıkar. Bu **sistematik** bir hatadır, rastgele değil.
+
+Bu ayrım havacılık sertifikasyonunun temel taşıdır. Yazılım tarafında olasılık hedefi yoktur; onun yerine **development assurance** (geliştirme güvencesi) vardır: DO-178C'nin DAL seviyeleri ve ARP4754B'nin FDAL/IDAL tahsisi. Hedef "yazılım $10^{-9}$ olasılıkla hata yapsın" değil, "hatanın kaçırılma ihtimalini azaltacak süreç titizliği DAL A'ya uygun olsun"dur.
+
+<div class="mermaid">
+graph TD
+    A[Ariza durumu siniflandirmasi - FHA] --> B[Rastgele donanim arizalari]
+    A --> C[Sistematik hatalar]
+    B --> D[Nicel hedef - ucus saati basina 10^-9]
+    C --> E[Gelistirme guvencesi - DAL ve FDAL-IDAL]
+    D --> F[FTA, PSSA, SSA]
+    E --> F
+</div>
+
+Pratik sonuç: bir emniyet analizinde donanım kolu nicel, yazılım kolu niteldir. Fault tree'nin yaprağına yazılım hatası için bir olasılık koyduğunuz an, o ağacın sayısal sonucu anlamını yitirir. (Fault tree ve minimal cut set hesabının kendisi ayrı bir yazının konusu.)
+
+---
+
+## Tahmin mi, kanıt mı? χ² ile MTBF'in alt sınırı
+
+Şimdiye kadar konuştuğumuz her şey *tahmindi*. Peki sahada gözlenen veriden MTBF nasıl çıkarılır — ve ne kadar güvenle?
+
+Üstel varsayım altında, toplam test süresi $T$ ve gözlenen arıza sayısı $r$ için MTBF'in nokta tahmini $T/r$'dir. Ama asıl işe yarayan sayı bu değil, alt güven sınırıdır. Zaman-kesikli (time-terminated) bir test için:
+
+$$
+\theta_{\text{alt}} = \frac{2T}{\chi^2_{C;\,2r+2}}
+$$
+
+Burada $C$ güven seviyesi; $\chi^2$ ise $2r+2$ serbestlik dereceli ki-kare dağılımının $C$ olasılığına karşılık gelen kuantili. (Kuantilleri çift serbestlik derecesi için kapalı formdan bisection ile hesaplayıp tabloyla doğruladım: $\chi^2_{0{,}90;\,2} = 4{,}6052$, $\chi^2_{0{,}90;\,4} = 7{,}7794$, $\chi^2_{0{,}95;\,6} = 12{,}5916$.)
+
+20 birimi 1.000'er saat çalıştırdığınızı, yani toplam $T$ = 20.000 birim-saat biriktirdiğinizi düşünelim:
+
+| Gözlenen arıza $r$ | Nokta tahmini $T/r$ | %60 güven alt sınırı | %90 güven alt sınırı |
+|---|---|---|---|
+| 0 | — | 21.827 saat | 8.686 saat |
+| 1 | 20.000 saat | 9.890 saat | 5.142 saat |
+| 3 | 6.667 saat | 4.790 saat | 2.994 saat |
+
+Hiç arıza görmeden 20.000 saat test etmek, %90 güvenle söyleyebileceğiniz tek şeyi verir: MTBF **en az 8.686 saat**. 100.000 saat değil.
+
+Peki 100.000 saatlik bir MTBF iddiasını sıfır arızayla, %90 güvenle kanıtlamak için ne kadar test gerekir? Formülü tersine çevirelim: $T = \theta \cdot \chi^2_{0{,}90;\,2}/2$, yani 100.000 × 4,6052 / 2 = 230.259 birim-saat. Yani 26,3 birim-yılı. Tek bir birimle 26 yıl; 100 birimlik bir filoyla yaklaşık 3,2 ay kesintisiz çalışma — ve bu süre boyunca **tek bir arıza bile olmayacak**.
+
+Bu hesabı bir kez yaptıktan sonra, datasheet'lerdeki 250.000 saatlik MTBF sayılarının nereden gelmediğini anlarsınız: ölçümden gelmiyorlar. Bir tablodan toplanarak hesaplanıyorlar. Bu onları değersiz yapmaz — ama ölçüm sanmak tehlikelidir.
+
+---
+
+## Sıcaklığın gerçek etkisi
+
+Tahmin el kitaplarının hepsi sıcaklık düzeltmesi yapar ve çoğu bunu Arrhenius bağıntısıyla modeller:
+
+$$
+\mathrm{AF} = \exp\!\left[\frac{E_a}{k}\left(\frac{1}{T_1} - \frac{1}{T_2}\right)\right]
+$$
+
+$E_a$ aktivasyon enerjisi (eV), $k = 8{,}617 \times 10^{-5}$ eV/K, sıcaklıklar Kelvin. Sayısal olarak:
+
+| $E_a$ | 40 °C → 70 °C | 40 °C → 85 °C |
+|---|---|---|
+| 0,3 eV | 2,6× | 4,0× |
+| 0,7 eV | 9,7× | 26,0× |
+
+Yani kartın çalışma sıcaklığını 40 °C'den 85 °C'ye çıkarmak, baskın arıza mekanizmasının aktivasyon enerjisine bağlı olarak arıza oranını 4 ile 26 kat arasında büyütüyor. Termal tasarımın güvenilirlik üzerindeki kaldıracı, bileşen kalite sınıfını yükseltmenin sağladığından tipik olarak daha büyük.
+
+Ama burada 217 eleştirisinin en haklı kısmı devreye giriyor: bu model yalnızca **durağan** sıcaklığı görür. Lehim bağlantısı yorulması, delik duvarı çatlağı, kalay whisker'ları gibi mekanizmalar sıcaklığın kendisinden çok **değişiminden** beslenir — bunlar Arrhenius'la değil, Coffin-Manson tipi çevrim modelleriyle anlatılır. Günde iki kez soğuk kalkış yapan bir aviyonik kutusu için sıcaklık çevrimi, ortalama sıcaklıktan daha belirleyici olabilir. FIDES'in misyon profili (uçuş fazlarına göre sıcaklık, titreşim, nem) tabanlı yaklaşımı tam olarak bu boşluğu kapatmak için var.
+
+---
+
+## Pratikte ne yapmalı
+
+Bu yazıdan çıkarmanızı istediğim işlemsel maddeler:
+
+1. **MTBF'i asla ömür olarak okumayın.** Servis ömrü (yıpranma) ayrı bir analizdir. Elektrolitik kondansatör, fan, röle, batarya, konnektör: bunların ömrü MTBF'ten bağımsız olarak sınırlıdır ve tipik olarak bu ömür, kutunun MTBF'inden çok daha kısadır.
+2. **MTBF yerine $R(t)$ isteyin.** Görev sürenizi söyleyin, o süredeki güvenilirliği isteyin. Tedarikçi bir dağılım varsayımı belirtemiyorsa sayı zayıftır.
+3. **Hangi metodolojiyle üretildiğini sorun.** MIL-HDBK-217F ile FIDES 2022, aynı karta 3-5 kat farklı arıza oranı verebilir. Metodoloji belirtilmemiş bir MTBF karşılaştırılamaz.
+4. **Varsayımları isteyin:** ortam kategorisi, ortalama bileşen sıcaklığı, duty cycle, kalite sınıfı. Bunlar olmadan sayı bir mertebe kayabilir.
+5. **Tahminleri mutlak değil, göreli kullanın.** Aynı metodoloji ve aynı varsayımlarla üretilmiş iki tasarımı karşılaştırmak meşrudur; tek bir tahmini saha performansının kestirimi saymak değildir.
+6. **Yedeklilikte onarım süresini tasarlayın.** MTTR, sistem MTBF'ine kadratik girer. Yer değiştirme süresi, yedek parça lojistiği ve arıza tespit kabiliyeti güvenilirlik parametreleridir.
+7. **Gizli arızaların test aralığını bir tasarım değişkeni sayın.** Maruz kalma süresi olasılığa doğrusal girer ve BIT tasarımıyla doğrudan kontrol edilebilir.
+8. **Yazılım için olasılık üretmeyin.** Nicel emniyet hedefi donanım kolu içindir; yazılım kolu DAL/FDAL tahsisiyle yönetilir.
+9. **Testten sayı çıkarırken güven sınırını yazın.** "MTBF = $T/r$" tek başına yanıltıcıdır; χ² alt sınırı gerçekte ne kanıtladığınızı söyler.
+
+---
+
+## Açık sorular ve ileri okuma
+
+Bu yazının bilerek dışarıda bıraktığı üç konu var ve her biri ayrı bir yazıyı hak ediyor:
+
+**Physics of Failure.** NRC raporunun önerdiği yön, sabit-$\lambda$ el kitaplarını tümüyle bırakıp mekanizma tabanlı modellemeye geçmek. Peki bu, bir sertifikasyon dosyasında nasıl kanıta dönüşür? Ömür modellemesi ile emniyet analizinin arayüzü hâlâ olgunlaşmış değil.
+
+**Bayesçi kestirim.** Telcordia SR-332'nin yaptığı gibi, saha verisiyle bir öncül tahmini güncellemek. Az veriyle çalışan aviyonik programları için doğal bir çerçeve; ama sertifikasyon otoritelerinin öncül seçimine bakışı ayrı bir tartışma.
+
+**Ortak sebep (common cause) arızaları.** Yukarıdaki bütün çarpımların dayandığı bağımsızlık varsayımı, özdeş iki kanalda çoğu zaman doğru değildir. $\beta$-faktör modelleri ve ayrışıklık (dissimilarity) gerektiren mimariler burada devreye girer — ve $10^{-9}$'a ulaşmanın gerçek zorluğu genellikle burada saklıdır.
+
+---
+
+## Kaynaklar
+
+- [MIL-HDBK-217F Notice 2, *Reliability Prediction of Electronic Equipment*, 28 Şubat 1995](https://everyspec.com/MIL-HDBK/MIL-HDBK-0200-0299/MIL-HDBK-217F_NOTICE-2_14590/)
+- [National Research Council, *Reliability Growth: Enhancing Defense System Reliability* (2015), Appendix D: Critique of MIL-HDBK-217](https://www.nationalacademies.org/read/18987/chapter/17)
+- [M. Pecht, F. Nash, "A critique of MIL-HDBK-217E reliability prediction methods", *IEEE Transactions on Reliability*, 1988](https://ieeexplore.ieee.org/document/9859/)
+- [FAA AC 25.1309-1B, *System Design and Analysis*, 30 Ağustos 2024](https://www.faa.gov/regulations_policies/advisory_circulars/index.cfm/go/document.information/documentID/1043037)
+- [SAE ARP4761A, *Guidelines for Conducting the Safety Assessment Process on Civil Aircraft, Systems, and Equipment*, Aralık 2023](https://www.sae.org/standards/content/arp4761a/)
+- [IEC 61709:2017, *Electric components — Reliability — Reference conditions for failure rates and stress models for conversion*](https://webstore.iec.ch/en/publication/28554)
+- [FIDES Guide 2022 — resmî site](https://www.fides-reliability.org/)
+- [Quanterion / RMQSI, *Confidence Bounds on the MTBF for a Time-Truncated Test*](https://www.rmqsi.org/confidence-bounds-on-the-mean-time-between-failure-mtbf-for-a-time-truncated-test/)
+- [Vertical Magazine, "Understanding 'one in a billion' in aircraft system safety assessments"](https://verticalmag.com/opinions/understanding-aircraft-system-safety-assessments/)
+- [Quanterion Solutions — MIL-HDBK-217 ve 217Plus durumu](https://www.quanterion.com/mil-handbook-217/)
+- [Telcordia SR-332 Issue 4 (Mart 2016) — Reliability Prediction Procedure for Electronic Equipment](https://telecom-info.njdepot.ericsson.net/site-cgi/ido/docs.cgi?ID=SEARCH&DOCUMENT=SR-332)

--- a/agent/research/2026-08-19-mtbf-bir-omur-degildir.md
+++ b/agent/research/2026-08-19-mtbf-bir-omur-degildir.md
@@ -1,0 +1,65 @@
+# Araştırma Notları — MTBF Bir Ömür Değildir (10⁻⁹ aritmetiği)
+
+Tarih: 2026-08-19 · Alan: güvenilirlik · Derinlik öğesi: matematiksel türetme + sayısal analiz
+
+## Neden bu konu (novelty)
+
+Türkçe kaynaklarda MTBF neredeyse tamamen "ortalama ömür" olarak yanlış anlatılıyor.
+Doğru içerik üç ayrı yerde dağınık duruyor: (a) pahalı/erişimi zor standart belgeleri
+(MIL-HDBK-217F, FIDES, IEC 61709), (b) sertifikasyon dokümanları (AC 25.1309-1B,
+ARP4761A), (c) akademik güvenilirlik literatürü. En kritik köprü — bileşen λ'sı ile
+10⁻⁹/uçuş saati hedefi arasındaki *maruz kalma süresi* çarpanı — Türkçe içerikte
+neredeyse hiç anlatılmıyor. Ayrıca "yazılımın MTBF'i" istenen RFP'ler hâlâ dolaşımda.
+
+Son 3 yayınlanan yazının alt-alanları: sistem düşüncesi (Antikırılgan), yazılım tasarımı
+(Coupling), navigasyon/füzyon (Kalman). Bu yazı "güvenilirlik" alanına dönüyor.
+Açık 53 PR'ın hiçbiri güvenilirlik tahmini / MTBF konusunu işlemiyor (en yakını #96 FTA,
+o da nitel cut-set analizi — çakışmıyor).
+
+## Doğrulanan olgular
+
+| İddia | Kaynak | Durum |
+|---|---|---|
+| MIL-HDBK-217F Notice 2 tarihi: 28 Şubat 1995 | Reliability Analytics / everyspec / NAVSEA PDF | ✔ |
+| MIL-HDBK-217G projesi tamamlanmadı; 217F N2 son revizyon | DLA PSMC sunumu, Quanterion | ✔ |
+| 217Plus:2015 Notice 1, Quanterion tarafından sürdürülüyor | quanterion.com | ✔ |
+| IEC 61709 Ed. 3.0 (2017), IEC 61709:2011 + IEC TR 62380:2004 birleşimi | IEC webstore | ✔ |
+| FIDES Guide 2022 Edition A; UTE C 80-811 referansı | fides-reliability.org | ✔ |
+| AC 25.1309-1B **30 Ağustos 2024**'te yayımlandı, 1A'yı iptal etti | FAA AC bilgi sayfası, Federal Register 2024-18511 | ✔ |
+| 2002 "Arsenal Draft" 1B yıllarca resmî olmadan atıf aldı | Wikipedia AC 25.1309-1 revizyon tablosu | ✔ |
+| Sınıflandırma: Katastrofik ≤1e-9, Tehlikeli ≤1e-7, Majör ≤1e-5 (uçuş saati başına) | AC 25.1309-1B / AMC 25.1309 | ✔ |
+| 10⁻⁹ türetmesi: ~4 kaza/10⁶ saat → %10 sistem kaynaklı → ~1e-7 → ÷100 olay = 1e-9 | Vertical Magazine (CS 25.1309 AMC'ye atıfla) | ✔ |
+| ARP4761A ve ARP4754B, 20 Aralık 2023'te yayımlandı (ED-135 / ED-79B) | ANSI webstore, SAE | ✔ |
+| NRC 2015 "Reliability Growth" Ek D: 217 tahmin/saha oranları 0.54–12.20, bir vakada 218:1 | nationalacademies.org/read/18987/chapter/17 | ✔ |
+| 217 eleştirisi (sabit λ, tek-nokta sıcaklık, π faktör bağımsızlığı) | Pecht & Nash 1988 IEEE Trans. Rel.; NRC 2015 Ek D | ✔ |
+| Zaman-kesikli test MTBF alt sınırı θ_L = 2T/χ²(C, 2r+2) | Quanterion/RMQSI Knowledge Center, Accendo | ✔ |
+
+## Hesaplanan sayılar (python3, tekrar üretilebilir)
+
+- λ=1/100000 h⁻¹, t=10 yıl=87.660 h → R=0.4162 → %58,4 arıza olasılığı.
+- Weibull β=3, MTTF aynı 100.000 h (η=111.985): R(10 yıl)=0.6190, R(15 yıl)=0.1981.
+  Üstel: R(10)=0.4162, R(15)=0.2685. → Aynı MTBF, ters sıralanan risk. Kesişim var.
+- 1oo2 onarımsız: MTTF = 1.5/λ (numerik integral 15.000 h @ λ=1e-4 ile doğrulandı).
+- 1oo2 onarımlı: MTTF=(3λ+μ)/(2λ²); λ=1e-4 için MTTR 8 h → 6.27e6 h (~715 yıl),
+  MTTR 168 h → 3.13e5 h (~36 yıl). Onarım süresi kadratik etkili.
+- χ² kuantilleri bisection ile hesaplandı, tabloyla doğrulandı
+  (χ²(0.90, 2)=4.6052; χ²(0.90, 4)=7.7794; χ²(0.95, 6)=12.5916).
+- 20.000 saat test, 0 arıza → %90 güvenle MTBF ≥ 8.686 h (nokta tahmin 20.000 h).
+- 100.000 h MTBF'i 0 arızayla %90 güvenle göstermek: 230.259 birim-saat (26,3 birim-yıl);
+  100 birimle ~3,2 ay.
+- Gizli arıza ortalama olasılığı: P̄ = 1 − (1−e^{−λT})/(λT) ≈ λT/2.
+  λT=0.005 için yaklaşım hatası %0,17; λT=0.5 için %17,3.
+- 50 FIT × 50 FIT, aktif+gizli çift arıza: T=100 h → 1.25e-13/h; T=2000 h → 2.50e-12/h.
+- Arrhenius: Ea=0.7 eV, 40→85 °C → AF=26.0; Ea=0.3 eV aynı sıçrama → AF=4.0.
+
+## Gizlilik kontrolü
+
+Yazının tamamı kamuya açık standart/literatür ve kendi türetmelerim üzerine kurulu.
+Proje adı, müşteri, iç süreç, gerçek λ verisi, tedarikçi datasheet'i yok. Sayısal
+örneklerin tamamı uydurma-ama-tipik değerlerle kurgulanmış ve öyle olduğu yazıda belirtiliyor.
+
+## Kullanılmayan / sonraya bırakılan
+
+- Coffin-Manson sıcaklık çevrimi modeli (yalnızca bir cümleyle anıldı; ayrı yazı olur)
+- Physics-of-Failure / PoF yaklaşımı ve CALCE metodolojisi (ayrı yazı adayı)
+- Bayesçi MTBF kestirimi (ayrı yazı adayı)

--- a/agent/topics.md
+++ b/agent/topics.md
@@ -1,16 +1,17 @@
 # Konu Defteri
 
 > Otonom yazı ajanının kalıcı belleği. Her çalıştırmada okunur ve güncellenir.
+> Son senkronizasyon: **2026-08-19**
 
 ## Yazıldı (yayında)
 
 - [x] Tümleşik Gereksinim Yönetimi — 2022-04-28 — alan: sistem/gereksinim
-- [x] Yazılım Sistem Mühendisliği — 2022-04-29 — alan: sistem
+- [x] Yazılım Sistem Mühendisliği — 2022-04-30 — alan: sistem
 - [x] Use Case Tuzakları — 2022-05-01 — alan: gereksinim/analiz
-- [x] Yazılım Proje Yönetimi Pratikleri — 2022-05-03 — alan: proje yönetimi
+- [x] Yazılım Proje Yönetimi Pratikleri — 2022-05-01 — alan: proje yönetimi
 - [x] Gereksinimler ve Test: Yedi Eksik Bağlantı — 2022-05-08 — alan: gereksinim/test
 - [x] Fonksiyonel Olmayan Yazılım Gereksinimleri — 2022-07-11 — alan: gereksinim
-- [x] CMake — 2022-07-20 — alan: araçlar
+- [x] CMake — 2022-07-19 — alan: araçlar
 - [x] Elektrik Kesintisinde Otomatik Açılış — 2022-08-15 — alan: sistem
 - [x] Recursively Delete a Specific Folder — 2022-09-11 — alan: araçlar
 - [x] Merge Files with FFmpeg — 2023-03-12 — alan: araçlar
@@ -22,107 +23,113 @@
 - [x] Ölçüm Belirsizliği (GUM Annex F + NCSLI RP-12) — 2026-05-06 — alan: metroloji
 - [x] Kalibrasyon Zincirinin Tepesi (Birincil Standartlar) — 2026-05-07 — alan: metroloji
 - [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14 — alan: gömülü/SoC
+- [x] Bandpass Sampling — 2026-05-21 — alan: RF/DSP
+- [x] Sistem Mühendisliği Nedir — 2026-05-26 — alan: sistem
+- [x] Kalman Filtresi — 2026-06-02 — alan: navigasyon/füzyon
+- [x] Coupling'i Dengelemek — 2026-06-04 — alan: yazılım tasarımı
+- [x] Antikırılgan: Belirsizlikten Güç Alan Sistemler — 2026-06-24 — alan: sistem düşüncesi
+
+**Son 3 yayın alt-alanı (rotasyon kısıtı için):** sistem düşüncesi · yazılım tasarımı · navigasyon/füzyon
 
 ## Açık PR'lar (insan inceleme bekleniyor)
 
-| PR # | Başlık | Dal | Açılış | Alan |
-|------|--------|-----|--------|------|
-| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | post/2026-05-20-crc-polinom-secimi-ve-hamming-mesafesi | 2026-05-20 | yazılım zanaatı/hata tespiti |
-| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR Geometrisi | post/2026-05-19-vor-faz-karsilastirma | 2026-05-19 | navigasyon |
-| [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A | post/2026-05-18-mcdc-kapsama-do-178c-dal-a | 2026-05-17 | sertifikasyon |
-| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi (C/C++, Rust) | post/bellek-guvenligi-devrimi | 2026-04-12 | gömülü/güvenlik |
-| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış (Undefined Behavior) | blog/undefined-behavior | 2026-04-04 | C/derleyici |
-| [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | blog/misra-c-statik-analiz | 2026-03-28 | standart/C (#69 ile çakışma riski!) |
-| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ (eski yazı genişletme) | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
+**2026-08-19 itibarıyla 53 açık PR var.** Tek tek listelemek defteri okunmaz hâle getirdiği
+için güncel liste artık burada tutulmuyor; kaynak doğrudan GitHub:
 
-> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. İnceleyen kişinin dikkatine.
+```bash
+gh pr list --repo mavrikant/mavrikant.github.io --state open --limit 100
+```
+
+Backlog, konu seçimi için **çakışma listesi** olarak her çalıştırmada okunmalı. Kapsanan
+alanların özeti (2026-08-19): DO-178C yapısal kapsama (MC/DC, object code, data/control
+coupling), DO-330, DO-326A, WCET (3 ayrı PR), `volatile`/`_Atomic` (**7 ayrı PR** — ciddi
+tekrar), ARINC 653, ARINC 664/AFDX, MIL-STD-1553B, multicore CAST-32A/AC 20-193, RTOS
+çizelgeleme (RMS, priority inversion), ARM (boot, GIC, MPU/MMU, DMA/cache, lockstep),
+linker script, watchdog (2 PR), deterministik derleme, statik analiz/abstract
+interpretation, stack analizi, `setjmp`/`longjmp`, bit-field/endianness (2 PR), CRC,
+sabit nokta, SEU/ECC, FTA, navigasyon (VOR, ILS, RAIM, Allan deviation, Kalman iraksama),
+I/Q örnekleme, bellek güvenliği, UB.
+
+> **İnceleyen kişinin dikkatine (öncelik önerisi):**
+> 1. `volatile`/`_Atomic` konusunda 7 açık PR var (#100, #134, #155, #156, #157, #159 ve
+>    ilgili). Biri seçilip diğerleri kapatılmalı — aksi hâlde bu konu backlog'u kilitliyor.
+> 2. WCET için 3 PR (#88, #98, #164), watchdog için 2 PR (#89, #161), bit-field/endianness
+>    için 2 PR (#122, #166) aynı durumda.
+> 3. #51 "MISRA C ve Statik Analiz", yayındaki "MISRA C:2025 ile Neler Değişti" ile çakışıyor.
+> 4. En eski PR'lar (#50, #51, #54) beş aydır bekliyor.
 
 ## Seçildi / Devam Eden
 
-- **Bandpass Sampling: 1 GHz Sinyali 50 MHz Saatle Örneklemek** —
-  dal: `post/2026-05-21-bandpass-sampling`,
-  dosya: `_posts/2026-05-21-bandpass-sampling.md`,
-  durum: PR açılacak (bu çalıştırma) — alan: RF/DSP.
+- **MTBF Bir Ömür Değildir: 10⁻⁹ Hedefinin Aritmetiği** —
+  dal: `post/2026-08-19-mtbf-bir-omur-degildir`,
+  dosya: `_posts/2026-08-19-mtbf-bir-omur-degildir.md`,
+  araştırma: `agent/research/2026-08-19-mtbf-bir-omur-degildir.md`,
+  alan: **güvenilirlik**, derinlik öğesi: matematiksel türetme + sayısal analiz,
+  durum: PR açıldı (2026-08-19).
 
-## Reddedildi (bu çalıştırma)
+## Reddedildi
 
-- _(bu çalıştırmada konu reddedilmedi; bandpass sampling havuzdan seçildi.)_
+- **ARINC-429 anatomisi** — 2026-08-19 — gerekçe: açık PR'larda zaten MIL-STD-1553B (#173)
+  ve AFDX/ARINC 664 (#165) var; üçüncü bir "veri yolu anatomisi" yazısı backlog'da
+  doygunluk yaratır.
+- **Barometrik irtifa ve ISA modeli** — 2026-08-19 — gerekçe: konu güçlü ve hâlâ havuzda,
+  ama alan rotasyonu kısıtına takıldı (son yayınlanan Kalman yazısı navigasyon alanındaydı).
+  Bir sonraki tur için birinci öncelikli aday.
+- **CORDIC algoritması** — 2026-08-19 — gerekçe: #114 (sabit nokta Q15) ile aynı alt-alanda,
+  o PR merge edilene kadar bekletilmeli.
+- (önceki turlardan) MISRA C statik analiz — yayındaki MISRA C:2025 yazısıyla çakışıyor.
 
-## Fikir Havuzu (aday konular — gelecek çalıştırma için)
+## Fikir Havuzu (aday konular)
 
-Aşağıdaki adaylar, mevcut yazılar + açık PR'larla çakışmıyor ve Bölüm 6 kriterlerini
-geçici olarak karşılıyor. Faz 2'de tekrar değerlendirilmesi gerekir.
+### Yüksek öncelikli (kalıcı değer + Türkçe boşluk + backlog'da yok)
 
-### Yüksek öncelikli (kalıcı değer + Türkçe boşluk)
+- [ ] **Barometrik irtifa ve ISA modeli** — alan: aviyonik/sensör — soğuk hava irtifa hatası,
+      ICAO düzeltme tabloları, QNH/QNE geçişi; türetme + sayısal örnek. *(bir sonraki tur)*
+- [ ] **Ortak sebep (common cause) arızaları ve β-faktör modeli** — alan: güvenilirlik —
+      bu turdaki MTBF yazısının doğal devamı, ama en az bir tur beklemeli
+- [ ] **Physics of Failure: sabit-λ'dan mekanizma tabanlı modellemeye** — alan: güvenilirlik
+- [ ] **CORDIC: FPU'suz donanımda trigonometri** — alan: DSP/matematik *(#114 bekliyor)*
+- [ ] **ARINC-429 anatomisi** — alan: veri yolu *(#173/#165 merge olduktan sonra)*
+- [ ] **IEEE 1588 / PTP: aviyonikte zaman senkronizasyonu** — alan: dağıtık sistem
+- [ ] **GPS sinyal edinimi: korelasyon, C/A kodu, edinim/izleme döngüleri** — alan: navigasyon
+- [ ] **Türetilmiş gereksinimler (derived requirements) ve emniyet değerlendirmesine geri
+      besleme** — alan: sertifikasyon/gereksinim — DO-178C §5.1.1'in en çok tartışılan maddesi
+- [ ] **Dead code vs deactivated code: DO-178C §6.4.4.3** — alan: sertifikasyon
+- [ ] **Formel doğrulama pratikte: SPARK / Frama-C ile bir fonksiyonun kanıtı** — alan: doğrulama
 
-- [ ] **ARM Cortex-A reset vektöründen `main()`'e: gerçekten ne oluyor?** —
-      alan: gömülü/SoC — Renode yazısının doğal devamı, somut deney imkânı
-- [ ] **MC/DC kapsama: DO-178C DAL A'da neden modified condition/decision şart?** —
-      alan: sertifikasyon — gerçek karar tablosu örneği, decision/condition farkı
-- [ ] **CRC vs checksum: neden CRC-32 değil de CRC-32C / CRC-16-CCITT seçilir?** —
-      alan: yazılım zanaatı — polinom seçimi, hata tespit gücü, bit-hata analizi
-- [ ] **WCET analizi: statik analiz vs ölçüm tabanlı yaklaşımlar, cache etkileri** —
-      alan: gerçek zamanlı — somut örnek (örn. Cortex-R5 üzerinde basit görev)
-- [ ] **IQ örnekleme ve karmaşık sinyaller: gerçek SDR'ye giriş** —
-      alan: RF/SDR — neden negatif frekans, neden 2 kanal
-- [ ] **GIC (Generic Interrupt Controller): SGI/PPI/SPI farkları ve önceliklendirme** —
-      alan: ARM — kesme yönlendirme, multicore'da CPU affinity
-- [ ] **Cache coherency ve MESI: ARM'da CCI/CMN ne yapar, neden yazılım perde
-      (barrier) gerekir?** — alan: ARM — pratik race condition örneği
-- [ ] **Linker script anatomisi: ARM bare-metal için bir `.ld` dosyası satır satır** —
-      alan: gömülü — kendi linker script'i yazma rehberi
-- [ ] **Watchdog tasarım desenleri: tek vs çoklu görev watchdog, deadman switch,
-      windowed watchdog** — alan: güvenilirlik — gerçek tasarım kararları
-- [ ] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
-      alan: C/eşzamanlılık — derleyici çıktı analizi
-- [ ] **VOR'un çalışma prensibi: 30 Hz referans + değişken faz nasıl yön verir?** —
-      alan: navigasyon — faz farkı matematiği + sinyal şeması
-- [ ] **ILS anatomisi: localizer 90/150 Hz DDM ve glide slope** —
-      alan: navigasyon — modülasyon derinliği farkı + örnek hesap
-- [ ] **Kalman filtresi tuzakları: numerik stabilite, gözlemlenebilirlik, tuning** —
-      alan: navigasyon/füzyon — basit IMU örneği + Python kodu
-- [ ] **Sabit nokta (Q-format) aritmetik: Cortex-M0'da FPU yokken DSP nasıl yapılır?** —
-      alan: gömülü/DSP — Q15/Q31 örnekleri, overflow yönetimi
+### Orta öncelikli
 
-### Orta öncelikli (kovaya alındı)
-
-- [ ] DO-330 araç nitelendirme (Tool Qualification) seviyeleri
-- [ ] ARP4754A — sistem geliştirme süreci
-- [ ] DO-326A / ED-202A havacılık siber güvenliği
+- [ ] MTBF üzerine Bayesçi kestirim (Telcordia yaklaşımı)
+- [ ] Coffin-Manson ve sıcaklık çevrimi kaynaklı yorulma
+- [ ] ARP4754B ile ARP4761A arasındaki iş bölümü — 2023 revizyonunun getirdikleri
+- [ ] ECSS uzay yazılım standartları ailesi (alt-konulara bölünmeli)
 - [ ] FMEA pratikte: gerçek bir alt-sistem üzerinden adım adım
-- [ ] Fault Tree Analysis ile minimal cut set hesabı
-- [ ] FPU denormal performansı: Cortex-A vs x86 davranış farkı
-- [ ] Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain
-- [ ] Endianness: ağ baytı vs host baytı, ARM'ın iki modu, bitfield tuzakları
-- [ ] DMA yarış koşulları: ARM'da cache invalidation/clean stratejileri
-- [ ] Lockstep CPU mimarisi: TI Hercules / NXP MPC57xx örnekleri
-- [ ] MPU vs MMU: hangisi ne zaman, FreeRTOS-MPU örneği
-- [ ] Statik analiz neyi yakalar / kaçırır: somut C kodu üzerinden Coverity/Polyspace
-- [ ] Radyasyona dayanıklı yazılım: SEU, TMR, scrubbing
+- [ ] Radyasyona dayanıklı yazılım: TMR, scrubbing *(#124 SEU/ECC ile kısmi çakışma)*
 - [ ] ADS-B sinyal yapısı: PPM modülasyon, mesaj formatı
 - [ ] FIR vs IIR: faz cevabı, hesaplama maliyeti, stabilite
 
 ### Düşük öncelikli / sonraya bırak
 
-- [ ] ECSS uzay yazılım standartları ailesi (geniş, alt-konulara bölünmeli)
 - [ ] DO-254 donanım sertifikasyonu (yazarın uzmanlığı ağırlıklı yazılım tarafında)
 - [ ] İzlenebilirlik matrisi (klasik konu, derinlik çıkarmak zor)
 
-## Notlar (bu çalıştırma — 2026-05-21)
+## Notlar (bu çalıştırma — 2026-08-19)
 
-- **Bandpass Sampling** seçildi (alan: RF/DSP). Önceki çalıştırmaların ardından
-  açılan PR'lar son üç alt-alanı (sertifikasyon #77, navigasyon #78, yazılım
-  zanaatı/CRC #79) işaretlemişti; bu yazı **bu üç alandan da** son yayınlanan 3
-  posttan da (Renode gömülü/SoC, kalibrasyon ×2) farklı bir alan getiriyor.
-- Yayın kapısı durumu: Bölüm 4 yalnızca "yayın PR ile olmalı" kuralı koyar; backlog
-  büyüklüğüne dair sert bir sınır yoktur. Açık 7 PR olmasına rağmen son yayınlanan
-  yazıdan (Renode, 2026-05-14) bu yana 7 gün geçti — `min_yayin_araligi_gun = 2`
-  şartı fazlasıyla sağlanmış durumda. Bu çalıştırmada yeni PR açıldı.
-- Bandpass sampling konusunun "neden Türkçe içerikte zor bulunuyor" yanıtı:
-  matematik (Vaughan 1991), datasheet okuma (analog input BW), saat phase noise
-  ve filtre tasarımı disiplinlerinin kesişiminde bulunuyor; Türkçe kaynaklar
-  genellikle yalnızca tek bir cepheden ele almış oluyor (genelde Lyons özet
-  çevirisi). Sentez ve somut sayısal örnek boşluğu büyük.
-- Açık PR'lar konusunda inceleme önceliği yorumu (gözlem): #50 ve #51 hâlâ uzun
-  süredir bekliyor; #50 eski yazıyı genişletiyor, #51 ise yayındaki MISRA C:2025
-  ile büyük olasılıkla çakışıyor. İnceleyen kişinin dikkatine.
+- Defter 2026-05-21'den beri güncellenmemişti; yayınlanan yazı listesi ve açık PR bölümü
+  bu turda `_posts/` ve `gh pr list` ile yeniden senkronize edildi.
+- **Konu seçimi:** 53 açık PR'ın hiçbiri güvenilirlik *tahmini* / MTBF konusunu işlemiyor.
+  En yakını #96 (Fault Tree Analizi) — o da nitel cut-set analizi, nicel tahmin metodolojisi
+  değil. Alan rotasyonu da sağlanıyor (son 3 yayın: sistem düşüncesi, yazılım tasarımı,
+  navigasyon).
+- **"Bu konuyu bulmak neden zor" yanıtı:** Türkçe içerikte MTBF neredeyse tamamen "ortalama
+  ömür" olarak yanlış anlatılıyor. Doğru bilgi üç ayrı ve pahalı kaynak kümesine dağılmış
+  durumda: standart belgeleri (MIL-HDBK-217F, FIDES 2022, IEC 61709, Telcordia SR-332),
+  sertifikasyon dokümanları (AC 25.1309-1B, ARP4761A) ve akademik güvenilirlik literatürü.
+  En kritik köprü — bileşen λ'sı ile 10⁻⁹/uçuş saati hedefi arasındaki *maruz kalma süresi*
+  çarpanı — hiçbir Türkçe kaynakta türetilmiş hâliyle bulunmuyor.
+- **Doğrulama:** Yazıdaki bütün sayılar kapalı formdan hesaplandı; 1oo2 MTTF sayısal
+  integrasyonla, χ² kuantilleri tabloyla, gizli-arıza yaklaşımı tam integralle çapraz
+  kontrol edildi. Yerel build (`bundle exec jekyll build`) temiz; tarayıcıda 101 MathJax
+  düğümü / 0 hata, 3 Mermaid diyagramı açık ve koyu temada sorunsuz render ediyor.
+- **Yayın kapısı:** son yayın 2026-06-24, aradan 56 gün geçti — `min_yayin_araligi_gun = 2`
+  fazlasıyla sağlandı.


### PR DESCRIPTION
## Seçilen konu ve neden seçildi

**MTBF Bir Ömür Değildir: 10⁻⁹ Hedefinin Aritmetiği** — alan: **güvenilirlik**.

- **Çakışma yok:** Repodaki 53 açık PR'ın ve yayındaki 23 yazının hiçbiri güvenilirlik *tahmini* / MTBF konusunu işlemiyor. En yakını #96 (Fault Tree Analizi); o da nitel cut-set analizi, nicel tahmin metodolojisi değil — bu yazı FTA'ya yalnızca tek cümleyle değinip konuyu ona bırakıyor.
- **Alan rotasyonu sağlanıyor:** son 3 yayınlanan yazının alt-alanları sistem düşüncesi (Antikırılgan), yazılım tasarımı (Coupling) ve navigasyon/füzyon (Kalman) idi.
- **Yayın kapısı:** son yayın 2026-06-24; aradan 56 gün geçti (`min_yayin_araligi_gun = 2`).

## Bu konu neden az bulunuyor?

Türkçe içerikte MTBF neredeyse tamamen "ortalama ömür" olarak yanlış anlatılıyor. Doğru bilgi üç ayrı ve erişimi pahalı kaynak kümesine dağılmış: standart belgeleri (MIL-HDBK-217F, FIDES 2022, IEC 61709, Telcordia SR-332), sertifikasyon dokümanları (AC 25.1309-1B, ARP4761A) ve akademik güvenilirlik literatürü. En kritik köprü — bileşen λ'sı ile 10⁻⁹/uçuş saati hedefi arasındaki **maruz kalma süresi** çarpanı — türetilmiş hâliyle hiçbir Türkçe kaynakta yok.

## Derinlik öğesi (Bölüm 7)

**Matematiksel türetme + sayısal analiz.** Yazının somut olarak türettiği/hesapladığı şeyler:

| Sonuç | Doğrulama |
|---|---|
| $R(t)$, MTTF ve MTBF $=1/\lambda$'nın hangi varsayım altında doğduğu | kapalı form |
| Aynı MTTF'li üstel vs Weibull ($\beta=3$) karşılaştırması — eğriler kesişiyor | $\eta = \mathrm{MTTF}/\Gamma(1+1/\beta)$ ile eşitlendi |
| 1oo2 onarımsız MTTF $= 3/(2\lambda)$ — "iki kat" değil 1,5 kat | sayısal integrasyonla doğrulandı (15.000,0 h @ λ=1e-4) |
| 1oo2 onarımlı MTTF $= (3\lambda+\mu)/(2\lambda^2)$ | 3 durumlu Markov zincirinden adım adım türetildi |
| Gizli arıza ortalama olasılığı $\bar{P}_A = 1-(1-e^{-\lambda T})/(\lambda T) \approx \lambda T/2$ | tam integral vs yaklaşım hatası ölçüldü (λT=0,005 → %0,17) |
| 50 FIT × 50 FIT çift arıza, test aralığına göre olasılık tablosu | tam formülden |
| χ² MTBF alt sınırı $2T/\chi^2_{C;2r+2}$ ve "100.000 h'i kanıtlamak 230.259 birim-saat sürer" | χ² kuantilleri bisection ile hesaplanıp tabloyla doğrulandı |
| Arrhenius hızlandırma faktörleri | kapalı form |

Ham hesaplar ve doğrulama notları: `agent/research/2026-08-19-mtbf-bir-omur-degildir.md`.

## Kullanılan kaynaklar

- MIL-HDBK-217F Notice 2 (28 Şubat 1995) — everyspec
- NRC, *Reliability Growth: Enhancing Defense System Reliability* (2015), Appendix D — tahmin/saha oranları 0,54–12,20; bir vakada 218:1
- Pecht & Nash, *IEEE Trans. Reliability* (1988) — 217E eleştirisi
- FAA AC 25.1309-1B (**30 Ağustos 2024**, AC 25.1309-1A'yı iptal etti)
- SAE ARP4761A (20 Aralık 2023)
- IEC 61709:2017 Ed. 3.0 · FIDES Guide 2022 Edition A · Telcordia SR-332 Issue 4 (2016)
- Quanterion/RMQSI — zaman-kesikli test için MTBF güven sınırları
- Vertical Magazine — 10⁻⁹ hedefinin tarihsel türetmesi

Bütün bağlantılar HTTP ile kontrol edildi ve erişilebilir.

## Öz-eleştiri (Faz 6) özeti

Eleştirmen fazında düzeltilenler:

- Mermaid etiketlerindeki `<br/>` kaldırıldı (kramdown bunları silip kelimeleri yapıştırıyor) ve kendine dönen kenar sadeleştirildi.
- Başlıktaki `$10^{-9}$` Unicode'a çevrildi — içindekiler bileşeni ham LaTeX gösteriyordu.
- Binlik ayracı içeren sayılar matematik modundan çıkarıldı (`$87.660$` MathJax'te ondalık gibi okunuyordu).
- ARP4761A'nın **belge yapısına** dair doğrulayamadığım iki iddia (hangi bölümde ne olduğu) yöntemsel ifadeyle değiştirildi — standart paywall'lı, yapısı doğrulanamadı.
- Boş başlık hücreli tablo düzeltildi; χ² kuantil notasyonu netleştirildi; Telcordia kaynağı eklendi.
- Gizli-arıza türetmesinin varsayımları (bağımsızlık, kusursuz test, λT ≪ 1) ve farklı konfigürasyonlarda çarpanın değişeceği yazıda açıkça belirtildi — kapalı form ezber olarak sunulmuyor.

## Gizlilik kontrolü

Yazının tamamı kamuya açık standart/literatür ve kendi türetmelerim üzerine kurulu. Proje adı, müşteri, iç süreç, gerçek tedarikçi verisi yok. Sayısal örneklerdeki bileşen sayısı/FIT değerleri temsilî ve yazıda öyle olduğu belirtiliyor.

## Doğrulama

- `bundle exec jekyll build` temiz (yalnızca mevcut Bootstrap Sass deprecation uyarıları).
- Yerel sunucuda tarayıcı kontrolü: **101 MathJax düğümü, 0 `mjx-merror`**, 3 Mermaid diyagramı SVG olarak render ediyor, 7 tablo, içindekiler tüm başlıkları yakalıyor.
- Açık ve koyu temada ayrı ayrı kontrol edildi; tema değişiminde diyagramlar yeniden render ediliyor.

---

> Bu PR otonom yazı ajanı tarafından hazırlandı. **Merge kararı insana aittir** — ajan kendi PR'ını merge etmez, onaylamaz, kapatmaz.
