### PR TITLE
Yeni yazı: Kod Doğru, Veri Yanlış — DO-178C'de Parameter Data Item

### DIFF
--- a/_posts/2026-08-24-do-178c-parameter-data-item.md
+++ b/_posts/2026-08-24-do-178c-parameter-data-item.md
@@ -1,0 +1,319 @@
+---
+title: "Kod Doğru, Veri Yanlış: DO-178C'de Parameter Data Item"
+subtitle: "When the Code Is Right and the Data Is Wrong: Parameter Data Items in DO-178C"
+background: "/img/posts/4.webp"
+date: '2026-08-24 06:00:00'
+layout: post
+lang: tr
+mermaid: true
+categories: [aviyonik]
+tags: [do-178c, sertifikasyon, gomulu-sistemler]
+---
+
+Emniyet kritik yazılım tartışmalarının neredeyse tamamı kodun etrafında döner: MC/DC kapsama, statik analiz, izlenebilirlik matrisi, derleyici nitelendirmesi. Oysa sahada gördüğüm en sinsi arızaların çoğu koddan değil, **kodun okuduğu veriden** çıkıyor. Kalibrasyon tabloları, limit değerleri, konfigürasyon blob'ları, uçuş zarfı parametreleri, bölümleme zaman bütçeleri... Bunlar derlenmiyor, birim testine girmiyor, çoğu projede "veri işte" diye kenarda duruyor. Ve kod kusursuz çalışırken sistem yanlış davranıyor.
+
+DO-178C bu boşluğu kapatmak için DO-178B'de hiç olmayan bir kavram getirdi: **Parameter Data Item (PDI)**. Bu yazı, PDI'ın standartta nerede geçtiğini, hangi maddesinin en çok kaçırıldığını ve bir PDI dosyasının hedefte sessizce yanlış okunmasının ne kadar kolay olduğunu gerçek bir derleme çıktısı üzerinden anlatıyor. Sonunda da, yükleme anında bu hataları reddeden bir okuyucunun nasıl kurulduğunu gösteriyorum.
+
+---
+
+## Neden bu konu az konuşuluyor
+
+PDI, ücretli bir standardın içine gömülü, birbirinden kopuk sekiz-on paragrafa dağılmış bir kavram. Tek bir "PDI bölümü" yok: planlamada bir bullet, gereksinimlerde bir cümle, doğrulamada ayrı bir alt bölüm, konfigürasyon yönetiminde bir genişletme, Annex A'da iki objektif. Standardı satın alıp baştan sona okumadıysanız — ki çoğu mühendis okumaz, projedeki plan dokümanlarını okur — kavramın bütününü hiçbir yerde göremezsiniz. Türkçe kaynak ise pratikte yok. İngilizce kaynakların çoğu da eğitim şirketlerinin pazarlama sayfaları; standardın hangi maddesinin ne dediğini net söyleyen az.
+
+İyi haber şu: FAA'in kamuya açık **"DO-178B/C Differences Tool"** dokümanı, DO-178C'nin hangi bölümlerine PDI'nın nasıl girdiğini madde madde listeliyor. Aşağıdaki haritanın omurgası oradan geliyor.
+
+---
+
+## Önce hikâye: 9 Mayıs 2015, Sevilla
+
+A400M MSN023 ilk uçuşuna çıktı. Uçak Haziran'da Türk Hava Kuvvetleri'ne teslim edilecekti. Havalanıştan kısa süre sonra Sevilla San Pablo havalimanına 5 km'den yakın bir noktada, La Rinconada'ya düştü; altı mürettebattan dördü hayatını kaybetti.
+
+Kamuya açık kaynaklara göre olayın kökeni şuydu: uçuşun öncesinde motorların **ECU (Engine Control Unit)** yazılımı Airbus tesisinde yeniden yüklenirken, üç motorda **tork kalibrasyon parametre verisi kazara silindi ve geri yazılmadı**. FADEC'ler bu parametreleri okuyamadığı için motorlar korumalı bir moda düştü. Airbus'ın ifadesiyle "1, 2 ve 3 numaralı motorlar havalanıştan sonra *power frozen* durumuna geçti ve mürettebatın güç ayarını normal yolla değiştirme girişimlerine yanıt vermedi."
+
+Bu vakanın bu yazı için kritik olan üç ayrıntısı var:
+
+1. **Kod doğruydu.** ECU'daki uygulama yazılımı sertifikalıydı ve beklendiği gibi çalışıyordu. Yanlış olan, o yazılımın okuduğu veriydi.
+2. **Yükleme "başarılı" göründü.** Veri eksikliği yükleme anında değil, uçuş sırasında ortaya çıktı.
+3. **Yerde hiçbir kokpit uyarısı yoktu.** Basına yansıyan bilgiye göre mürettebatın alacağı ilk uyarı, uçak yaklaşık 120 metre irtifadayken geliyordu — yani kalkışı iptal etmenin çoktan imkânsız olduğu noktada.
+
+Sevilla kazasının resmî teknik raporu İspanya Silahlı Kuvvetleri kaza komisyonu CITAAM tarafından yürütüldü ve tamamı kamuya açık değil; bu yüzden yukarıdaki ayrıntıları "kesin sebep" diye değil, **kamuya açık kaynakların anlattığı senaryo** olarak okuyun. Ama senaryonun mühendislik dersi, resmî raporun ayrıntılarından bağımsız olarak geçerli: bir konfigürasyon verisinin yokluğu, sistemi sessizce güvenli olmayan bir duruma sokabiliyor.
+
+Bağlam için: A400M'in 13 Mart 2013 tarihli bir EASA sivil tip sertifikası var, TP400-D6 motorunun da ayrı bir EASA motor tip sertifikası (EASA.E.033) bulunuyor ve motorun tip sertifikası veri sayfası FADEC'i "Engine Control Unit and Application Software" olarak listeliyor. Yani bu, sivil sertifikasyon dünyasının kavramlarının doğrudan uygulandığı bir alan.
+
+---
+
+## DO-178C'nin cevabı: Parameter Data Item
+
+DO-178C, Annex B sözlüğüne iki yeni terim ekledi. PDI'ın tanımı özetle şu: *Parameter Data Item File biçiminde olduğunda, Executable Object Code'u değiştirmeden yazılımın davranışını etkileyen ve **ayrı bir konfigürasyon öğesi olarak yönetilen** veri kümesi.*
+
+Tanımın her parçası kasıtlı:
+
+- **"Executable Object Code'u değiştirmeden"** — PDI'yı değiştirmek için yeniden derleme gerekmez. Güç de buradan gelir, tehlike de.
+- **"Yazılımın davranışını etkileyen"** — yani bir log dosyası ya da kullanıcı tercihi değil. Sistemin fonksiyonel davranışını belirleyen veri.
+- **"Ayrı bir konfigürasyon öğesi"** — kendi part number'ı, kendi baseline'ı, kendi izlenebilirliği olan bağımsız bir yaşam döngüsü verisi.
+
+Bu tanımın en önemli sonucu şu: **PDI, "veri" olduğu için daha az disiplin gerektiren bir şey değil.** Aksine, DO-178C'nin planlama maddesi (§4.2.j) açıkça PDI'ların *software level*'ının planlarda belirlenmesini istiyor. DAL A bir fonksiyonun davranışını belirleyen bir kalibrasyon tablosu, pratikte DAL A titizliğiyle üretilip doğrulanması gereken bir yaşam döngüsü verisidir.
+
+### PDI'ın DO-178C haritası
+
+DO-178C'de tek bir "PDI bölümü" yok; kavram yaşam döngüsünün her aşamasına serpiştirilmiş durumda:
+
+| Bölüm | Ne diyor |
+|---|---|
+| **§2.5.1 Parameter Data Items** | Yeni bölüm. PDI'ın ne olduğunu, neler içerdiğini ve nelerin ele alınması gerektiğini tanımlar |
+| **§4.2.j** | Planlamada ele alınacaklar: PDI'ların kullanım şekli, **software level'ı**, geliştirme/doğrulama/değiştirme süreçleri, ilgili **araç nitelendirmesi**, yükleme kontrolü ve uyumluluk |
+| **§5.1.2** | Üst seviye gereksinimler PDI'ın nasıl kullanıldığını, **yapısını**, her veri elemanının **özniteliklerini** ve uygulanabildiğinde **değerlerini** belirtmeli |
+| **§5.4.1a / §5.4.2** | Entegrasyon süreci artık PDI dosyalarını da üretir |
+| **§6.6 Verification of Parameter Data Items** | Yeni bölüm. PDI doğrulamasının EOC doğrulamasından **ayrı** yürütülebilmesi için sağlanması gereken koşulları ve doğrulama faaliyetlerini verir |
+| **§7.2.1.e, §7.2.7.d/e** | Konfigürasyon tanımlama ve arşivleme kapsamı PDI dosyalarını içerecek şekilde genişletildi |
+| **§8.3.e** | Conformity review: PDI dosyaları da arşivlenmiş kaynaktan **yeniden üretilebilmeli** |
+| **§11.16** | Software Configuration Index, kullanılan PDI dosyalarını ve build talimatlarındaki yerini açıkça tanımlamalı |
+| **§11.22 Parameter Data Item File** | Yeni bölüm. PDI dosyasının neyden oluştuğunu açıklar |
+| **Tablo A-2** | Hedefe yüklenmeye ilişkin objektife PDI eklendi |
+| **Tablo A-5** | **İki yeni objektif** eklendi: PDI dosyasının doğru ve tam olması, ve doğrulanmış olması |
+
+Tablo A-5'e eklenen iki objektif ikincil kaynaklarda genellikle **#8** ("Parameter Data Item File is correct and complete") ve **#9** (bu doğrulamanın gerçekleştirilmiş olması) diye numaralandırılıyor. FAA'in farklar dokümanı numara vermeden "iki ek objektif" diyor; numaralandırmayı bu kayıtla kullanın. Bu arada, bazı ikincil kaynaklarda PDI objektiflerinin Tablo A-6 ve A-7'de olduğu yazıyor — bu büyük olasılıkla hatalı; A-7'nin dokuzuncu objektifi yaygın olarak kaynak koda izlenemeyen ek kodun doğrulanması (object code verification) objektifi olarak biliniyor.
+
+<div class="mermaid">
+flowchart TB
+    SYS["Sistem süreçleri - ARP4754A"] --> HLR["§5.1.2 HLR: PDI nasıl kullanılır, yapısı, öznitelikleri, değerleri"]
+    HLR --> INT["§5.4.1a Entegrasyon: PDI File üretilir"]
+    HLR --> V66["§6.6 PDI doğrulaması - EOC'den ayrı olabilir"]
+    INT --> V66
+    V66 --> A5["Tablo A-5: PDI File doğru ve tam + doğrulandı"]
+    INT --> CM["§7.2.1.e / §7.2.7 Konfigürasyon kimliği ve arşiv"]
+    CM --> SCI["§11.16 SCI: hangi PDI dosyası, hangi build"]
+    CM --> CONF["§8.3.e Conformity: arşivden yeniden üretilebilir mi"]
+    A5 --> LOAD["§7.4 Software Load Control + ARINC 665 / 615A"]
+    SCI --> LOAD
+    LOAD --> TGT["Hedef donanım: EOC + PDI File"]
+</div>
+
+---
+
+## En çok kaçırılan madde: §5.1.2
+
+PDI ile ilgili projelerde en sık atlanan yer, doğrulama tarafı değil **gereksinim** tarafı. DO-178C §5.1.2, PDI planlanıyorsa üst seviye gereksinimlerin şunları belirtmesini istiyor:
+
+- PDI'ın yazılım tarafından **nasıl kullanıldığını**,
+- PDI'ın **yapısını** (structure),
+- her veri elemanının **özniteliklerini** (attributes),
+- uygulanabildiğinde her elemanın **değerini**,
+
+ve ek olarak: eleman değerleri, PDI'ın yapısı ve veri elemanlarının öznitelikleriyle **tutarlı** olmalı.
+
+Bu maddeyi bir sertifikasyon formalitesi gibi okumak kolay. Ama pratikte söylediği şey çok somut: **PDI dosyasının ikili düzeni bir gereksinim nesnesidir.** Alan sırası, alan genişliği, işaretlilik, ölçek birimi, geçerli aralık, endianlık — bunların hepsi HLR'de tanımlanmış olmak zorunda, çünkü hedefteki kod bu düzene göre okuma yapacak.
+
+Bunu yapmadığınızda ne olduğunu göstermenin en iyi yolu, denemek.
+
+---
+
+## Deney: bir PDI dosyasını struct'a serimlemek
+
+Aşağıdaki deneyi kendi makinemde (Apple clang 21.0.0, `arm64-apple-darwin25.5.0`, `gcc -std=c11 -O2 -Wall -Wextra`) çalıştırdım; çıktılar birebir kopyalanmıştır. Senaryo sentetik ama düzeni gerçek hayattan tanıdıksınız: bir tork kalibrasyon PDI'ı, dört alan, 12 bayt.
+
+Üretici taraftaki araç bu yapıyla yazıyor:
+
+```c
+typedef struct {
+    uint16_t schema;          /* şema sürümü          */
+    uint16_t n_points;        /* tablo eleman sayısı  */
+    float    k_nm_per_count;  /* ölçek  [Nm/count]    */
+    float    offset_nm;       /* sıfır noktası [Nm]   */
+} calib_gen_t;
+```
+
+Hedefteki EOC ise aynı şema sürümünü okuduğunu düşünüyor, ama başlık dosyası bir revizyonda "okunabilirlik için" düzenlenmiş ve iki `float` alanın sırası değişmiş:
+
+```c
+typedef struct {
+    uint16_t schema;
+    uint16_t n_points;
+    float    offset_nm;       /* <-- yer değiştirdi */
+    float    k_nm_per_count;
+} calib_eoc_t;
+```
+
+İki yapının **boyutu aynı**: 12 bayt. Derleyici hiçbir uyarı vermez. `schema` alanı hâlâ 1 okunur, `n_points` hâlâ 4 okunur — yani naif bir "şema sürümü kontrolü" bile bu hatayı yakalayamaz. Dosya sorunsuz "yüklenir".
+
+```text
+== Yapı düzeni ==
+sizeof(calib_gen_t) = 12, sizeof(calib_eoc_t) = 12
+gen: schema@0 n_points@2 k@4 offset@8
+eoc: schema@0 n_points@2 k@8 offset@4
+
+== PDI dosyası (12 bayt) ==
+uretici yazdi:        01000400 0000003E 000016C2
+
+== Senaryo 1: doğru şema ==
+k=0.1250 offset=-37.50 -> tork = 337.50 Nm
+
+== Senaryo 2: alan sırası değişmiş EOC aynı dosyayı okuyor ==
+okunan: schema=1 n_points=4 k=-37.5000 offset=0.12
+-> tork = -112499.88 Nm  (beklenen 337.50 Nm)
+```
+
+Hexdump'ı okumak öğretici: little-endian'da `0000003E` baytları `0x3E000000` yani `0.125f`, `000016C2` ise `0xC2160000` yani `-37.5f`. İki alan yer değiştirdiği anda ölçek katsayısı `-37.5` oluyor ve 3000 sayaçlık ham okuma **-112499.88 Nm**'ye dönüşüyor. Hiçbir hata kodu, hiçbir kesme, hiçbir log yok. Sadece yanlış bir sayı.
+
+Şimdi asıl ilginç kısım — PDI bölgesinin hiç yazılmamış olduğu durumlar:
+
+```text
+== Senaryo 3: PDI bölgesi silinmiş (flash erased, 0xFF) ==
+okunan: schema=65535 n_points=65535 k=nan offset=nan
+-> tork = nan Nm
+
+== Senaryo 4: PDI bölgesi sıfırlanmış (0x00) ==
+okunan: schema=0 n_points=0 k=0 offset=0
+-> tork = 0 Nm  (her ham değerde 0 — sensör 'sağlam', motor 'tork üretmiyor')
+```
+
+Dördüncü senaryo, bu yazının kalbi. Silinmiş bir flash bölgesi ya da sıfırlanmış bir RAM alanı, `float` olarak okunduğunda **tam olarak 0.0f** verir — çünkü IEEE-754'te tamamı sıfır olan bit deseni geçerli bir sayıdır, hem de en masum görünenidir. Bir ölçek katsayısı sıfır olduğunda sistem çökmez, hata vermez, bölme hatası üretmez. Sadece **her ham okumayı sıfıra çevirir**. Sensör sağlıklı, kablo sağlam, kod doğru; ölçülen büyüklük ise kalıcı olarak sıfır.
+
+Üçüncü senaryonun (`0xFF` silinmiş flash) ürettiği `NaN` aslında daha şanslı bir durum: `NaN` en azından tüm karşılaştırmalarda `false` döndürerek çoğu aralık kontrolünü tetikler. Sıfır ise hiçbir şeyi tetiklemez. Yani **en tehlikeli bozuk veri, en makul görünen bozuk veridir.**
+
+---
+
+## Sessiz varsayılan sorunu
+
+Yukarıdaki dört senaryonun ortak paydası, kodun hiçbir aşamada "bu veri gerçekten yüklendi mi?" sorusunu sormaması. Gömülü yazılımda bu, birkaç yaygın alışkanlıktan doğuyor:
+
+- **Struct serimleme (overlay).** `memcpy(&cfg, flash_addr, sizeof cfg)` ya da doğrudan `(const cfg_t *)FLASH_BASE` cast'i. Bu, dosya biçimini derleyicinin ABI kararlarına — padding, hizalama, bit-field sıralaması, endianlık — teslim etmek demektir. §5.1.2'nin "yapı ve öznitelikler HLR'de tanımlanmalı" maddesi tam da bunu engellemek için var.
+- **Statik başlatıcıyla "güvenli varsayılan".** `static cfg_t cfg = { .k = 0.0f };` gibi bir varsayılan, yükleme başarısız olduğunda kodu çalışır durumda tutar. Kâğıt üzerinde savunmacı görünür; pratikte arızayı gizler.
+- **`.bss` sıfırlaması.** PDI yapısı başlatılmamış bir global ise, C çalışma zamanı onu zaten sıfırlar. Yükleme hiç olmasa bile değişken "geçerli" görünen sıfırlarla dolar.
+- **Yükleme kontrolünü taşıma katmanına havale etmek.** ARINC 665 tabanlı bir yükleme parçasının kendi CRC alanları vardır ve ARINC 615A yüklemesi başarıyla biter. Ama bu yalnızca **baytların doğru taşındığını** kanıtlar; taşınan baytların doğru PDI olduğunu, doğru sürüm olduğunu ya da hedefteki EOC'ye uyduğunu kanıtlamaz.
+
+DO-178C §6.6'nın PDI doğrulamasını EOC doğrulamasından ayırma imkânı tanımasının bedeli de burada ortaya çıkıyor: PDI'yı bağımsız doğrulayabiliyorsanız, EOC'nin o PDI'yı **çalışma zamanında** doğru şekilde yorumladığını gösteren ayrı bir kanıta ihtiyacınız var. İkisi arasındaki sözleşme, tam olarak dosya biçiminin kendisidir.
+
+---
+
+## Savunma deseni: yükleme anında reddeden okuyucu
+
+Çözüm karmaşık değil, sadece disiplinli. PDI dosyasına kendi kendini tanımlayan bir çerçeve koyun ve okuma işlemini bayt akışından açık biçimde yapın:
+
+```c
+#define PDI_MAGIC   0x50444931u   /* "PDI1" */
+#define PDI_SCHEMA  1u
+#define PDI_LEN     24u  /* magic4 + schema2 + npts2 + k4 + off4 + partno4 + crc4 */
+
+/* Bayt akışından açık okuma — struct serimlemesi yok */
+static uint16_t rd16(const uint8_t *p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+static uint32_t rd32(const uint8_t *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+static float rdf32(const uint8_t *p) {
+    uint32_t u = rd32(p); float f; memcpy(&f, &u, 4); return f;
+}
+
+static pdi_status_t pdi_load(const uint8_t *buf, size_t len,
+                             uint32_t eoc_expects_part, calib_t *out)
+{
+    if (len != PDI_LEN)                       return PDI_ERR_LEN;
+    if (rd32(buf + 0) != PDI_MAGIC)           return PDI_ERR_MAGIC;
+    if (rd16(buf + 4) != PDI_SCHEMA)          return PDI_ERR_SCHEMA;
+    if (rd32(buf + 20) != crc32(buf, 20))     return PDI_ERR_CRC;
+
+    uint16_t n   = rd16(buf + 6);
+    float    k   = rdf32(buf + 8);
+    float    off = rdf32(buf + 12);
+    uint32_t pn  = rd32(buf + 16);
+
+    /* HLR'den gelen aralık ve öznitelik kontrolleri - DO-178C §5.1.2 */
+    if (n < 2u || n > 64u)                    return PDI_ERR_RANGE;
+    if (!(k > 0.01f && k < 10.0f))            return PDI_ERR_RANGE;   /* NaN da elenir */
+    if (!(off > -500.0f && off < 500.0f))     return PDI_ERR_RANGE;
+    if (pn != eoc_expects_part)               return PDI_ERR_COMPAT;
+
+    out->n_points = n; out->k_nm_per_count = k;
+    out->offset_nm = off; out->part_no = pn;
+    return PDI_OK;
+}
+```
+
+Aynı sekiz senaryoyu bu okuyucudan geçirdiğimde çıkan sonuç:
+
+```text
+1) gecerli PDI            -> OK  (k=0.125 off=-37.5 n=4)
+2) silinmis bolge (0x00)  -> REDDEDILDI: magic
+3) silinmis bolge (0xFF)  -> REDDEDILDI: magic
+4) tek bit bozulmus CRC   -> REDDEDILDI: CRC-32
+5) alanlar yer degistirmis-> REDDEDILDI: aralik disi deger
+6) yanlis part number     -> REDDEDILDI: EOC/PDI uyumsuz
+7) sema v2 dosyasi        -> REDDEDILDI: sema surumu
+8) kisa dosya (20 bayt)   -> REDDEDILDI: uzunluk
+```
+
+Tasarımdaki her kontrolün hangi arıza sınıfını yakaladığına dikkat edin — hiçbiri süs değil:
+
+| Kontrol | Yakaladığı arıza |
+|---|---|
+| Uzunluk | Kesilmiş/eksik yükleme, yanlış dosya |
+| Magic | Yazılmamış/silinmiş bölge, tamamen yanlış blob |
+| Şema sürümü | Biçim değişikliği sonrası eski/yeni dosya karışması |
+| CRC-32 | Bit bozulması, kısmi yazma, flash yıpranması |
+| Aralık kontrolü | Anlamsal bozulma: alan kayması, yanlış birim, `NaN` |
+| Part number uyumu | Yanlış motor pozisyonu, yanlış kuyruk numarası, yanlış varyant |
+
+Birkaç ayrıntı önemli:
+
+**Aralık kontrolünü pozitif biçimde yazın.** `if (!(k > 0.01f && k < 10.0f))` ifadesi, `k` `NaN` olduğunda da reddeder; çünkü `NaN` ile yapılan her karşılaştırma `false` döner. Bunu `if (k < 0.01f || k > 10.0f)` diye yazsaydınız `NaN` her iki testi de geçemez ve **kabul edilirdi**. Emniyet kritik kodda bu tek satırlık fark, üçüncü senaryoyu sessiz kabule çevirir.
+
+**CRC'yi doğrulayın, doğrulamasını da doğrulayın.** Yukarıdaki kod yansıtmalı CRC-32 (ters polinom `0xEDB88320`) kullanıyor. Uygulamanın doğruluğunu standart kontrol vektörüyle sınadım: `CRC32("123456789")` = `0xCBF43926` — beklenen değerle uyuşuyor. Kendi CRC rutininizi bu vektörle test etmiyorsanız, aslında ne hesapladığınızı bilmiyorsunuz demektir.
+
+**Part number uyumluluğu ayrı bir alandır.** DO-178C §4.2.j planlamada "software load control ve compatibility"yi açıkça saymış. Pratikte bu, PDI dosyasının hangi EOC baseline'ıyla ve hangi donanım pozisyonuyla eşleştiğinin **veri içinde** taşınması demek. Sevilla senaryosunun altında yatan sınıf tam olarak budur: doğru dosyanın doğru üniteye gitmemesi.
+
+**Ve reddettiğinizde ne yapacağınıza karar verin.** Bu, kodun değil sistem emniyet analizinin sorusu: PDI reddedildiğinde ünite hangi duruma geçmeli, bu durum operatöre **hangi aşamada** bildirilmeli? Sevilla vakasının en can alıcı ayrıntısı, uyarının varlığı ya da yokluğu değil, **zamanlamasıydı**: kalkışı iptal etmenin mümkün olduğu bir noktada gelmeyen uyarı, uyarı sayılmaz. Yükleme sonrası doğrulama, yer testinin bir parçası olmalı — uçuşun değil.
+
+---
+
+## Sık karıştırılan sınır: PDI mi, DO-200 verisi mi?
+
+Konfigürasyon verisi konuşulurken iki standart sürekli birbirine karışıyor.
+
+**DO-178C PDI**, yazılımın davranışını belirleyen ve yazılım yaşam döngüsü içinde üretilip doğrulanan konfigürasyon verisidir: kalibrasyon katsayıları, limitler, bölümleme zaman bütçeleri, filtre parametreleri.
+
+**DO-200B / DO-200C** (Avrupa'da ED-76A / ED-76B) ise tamamen farklı bir problemi çözer: *Standards for Processing Aeronautical Data*. Buradaki mesele, aeronautical verinin — navigasyon veritabanları, prosedürler, engel verileri — kaynaktan uçağa kadar uzanan **işleme zinciri boyunca kalitesinin korunması ve kanıtlanması**. Bu bir yazılım geliştirme standardı değil, bir veri kalite yönetimi standardıdır.
+
+Pratik ayrım şu soruyla yapılır: veri, **yazılımın nasıl davranacağını** mı belirliyor, yoksa yazılımın **üzerinde işlem yaptığı dünya bilgisi** mi? İlki PDI, ikincisi DO-200 dünyası. Bir FMS'in navigasyon veritabanı DO-200; aynı FMS'in performans hesabında kullandığı uçak-özel katsayı tablosu ise büyük olasılıkla PDI.
+
+---
+
+## Sahadan pratik notlar
+
+Bunları bir kontrol listesi gibi kullanabilirsiniz:
+
+1. **PDI'ları planlama aşamasında sayın.** PSAC/SDP'de "PDI kullanılmayacaktır" yazıp sonra bir kalibrasyon tablosu eklemek, en pahalı düzeltme yoludur. §4.2.j'nin istediği dört maddeyi (kullanım, seviye, süreç ve araç nitelendirmesi, yükleme kontrolü) baştan yanıtlayın.
+2. **Dosya biçimini bir gereksinim yapın.** Alan sırası, genişlik, işaretlilik, ölçek, birim, aralık ve endianlık HLR'de yazılı olsun. Bir `.h` dosyasındaki struct tanımı gereksinim değildir.
+3. **Struct serimleme yapmayın.** Bayt akışından açık okuma yazın. Bu, hem ABI bağımlılığını hem de derleyici sürümü değişikliğinde ortaya çıkan sürprizleri ortadan kaldırır.
+4. **Yokluğu bir arıza olarak tanımlayın.** "Veri yoksa varsayılan kullan" değil, "veri yoksa fonksiyonu sunma ve bildir". Sıfır, hiçbir zaman güvenli varsayılan değildir.
+5. **PDI'yı üreten aracı nitelendirme kapsamında değerlendirin.** PDI'ı bir Excel makrosu ya da Python betiği üretiyorsa ve bu aracın çıktısı doğrulama faaliyetiyle bağımsız olarak kontrol edilmiyorsa, DO-330 kapsamında bir tartışma kapıda demektir.
+6. **Conformity review'u simüle edin.** §8.3.e, PDI dosyasının arşivlenmiş kaynaktan yeniden üretilebilmesini istiyor. Bunu bir kez gerçekten deneyin: temiz bir makinede, sadece SCI'da yazılı olanla, bit-bit aynı dosyayı üretebiliyor musunuz?
+7. **Yükleme sonrası doğrulamayı test prosedürüne koyun.** Yüklemenin "başarılı" bitmesi ile verinin doğru olması iki ayrı iddiadır ve ikisi ayrı ayrı kanıt ister.
+
+---
+
+## Açık sorular
+
+Bu konuda hâlâ net bir konsensüs görmediğim birkaç nokta var:
+
+- **PDI'nın structural coverage'ı ne demek?** Kodun kapsama analizi olgun bir konu, ama "PDI eleman kapsaması" — yani her konfigürasyon elemanının en az bir gereksinim tabanlı testte gerçekten kullanılmış olması — projeler arasında çok farklı yorumlanıyor.
+- **Kombinatoryal patlama.** Yüzlerce elemanlı bir PDI, teorik olarak astronomik sayıda konfigürasyon üretir. "Yalnızca teslim edilecek konfigürasyonları doğrula" ile "biçimi ve aralıkları doğrula, değerler veri olarak ayrı yönetilsin" arasındaki tercih, projenin doğrulama maliyetini birkaç kat değiştirebiliyor.
+- **Alan güncellemeleri.** Sahada değişebilen PDI'lar (örneğin ünite değişiminde yeniden yüklenen kalibrasyonlar), sertifikasyon kanıtı ile operasyonel gerçeklik arasındaki en zayıf halka. Sevilla senaryosu tam olarak bu halkada kopmuştu.
+
+Kodun doğruluğuna yatırım yaparken, o kodun okuduğu veriye aynı gözle bakmıyorsak, doğrulama bütçesinin önemli bir kısmını yanlış yere harcıyoruz demektir.
+
+---
+
+## Kaynaklar
+
+- [FAA/AVS DO-178B/C Differences Tool, Rev. 010 (15.03.2014)](https://www.faa.gov/sites/faa.gov/files/aircraft/air_cert/design_approvals/air_software/differences_tool.pdf) — DO-178C'ye eklenen PDI bölümlerinin madde madde listesi
+- [RTCA DO-178C / EUROCAE ED-12C, Software Considerations in Airborne Systems and Equipment Certification](https://www.rtca.org/) — birincil standart (ücretli)
+- [2015 Seville Airbus A400M crash — Wikipedia](https://en.wikipedia.org/wiki/2015_Seville_Airbus_A400M_crash)
+- [Airbus sends Alert Operator Transmission to A400M operators (19.05.2015)](https://skiesmag.com/press-releases/airbussendsalertoperatortransmissiontoa400moperators/)
+- [Airbus warns of software bug in A400M transport planes — The Register](https://www.theregister.com/2015/05/20/airbus_warns_of_a400m_software_bug)
+- [EASA certifies the Airbus A400M (13.03.2013)](https://www.easa.europa.eu/en/newsroom-and-events/press-releases/easa-certifies-airbus-a400m)
+- [EASA.E.033 — Europrop International TP400-D6 engine type certificate](https://www.easa.europa.eu/en/document-library/type-certificates/engine-cs-e/easae033-europrop-international-gmbh-tp400-d6-engine)
+- [AdaCore — SPARK Parameter Data Item demo](https://github.com/AdaCore/SPARK_PDI_Demo) — PDI'ın kodla ilişkisine dair açık kaynak örnek
+- [RTCA DO-200B / EUROCAE ED-76A, Standards for Processing Aeronautical Data](https://ee-aero.com/glossary/do-200b/)
+- [Verification scenarios of onboard databases under RTCA DO-178C and RTCA DO-200B](https://www.researchgate.net/publication/320971082_Verification_scenarios_of_onboard_databases_under_the_RTCA_DO-178C_and_the_RTCA_DO-200B) — iki standardın sınırını tartışan akademik çalışma
+- [Rapita Systems — Verifying additional code for DO-178C](https://www.rapitasystems.com/object-code-verification) — Tablo A-7 objektifinin PDI ile karıştırılmaması için

--- a/agent/research/2026-08-24-do-178c-parameter-data-item.md
+++ b/agent/research/2026-08-24-do-178c-parameter-data-item.md
@@ -1,0 +1,94 @@
+# Araştırma Notları — DO-178C Parameter Data Item (PDI)
+
+Tarih: 2026-08-24 · Yazı: `_posts/2026-08-24-do-178c-parameter-data-item.md`
+
+## 1. Standart tarafı — doğrulanmış kaynak: FAA/AVS "DO-178B/C Differences Tool" Rev 010 (15.03.2014)
+
+İndirildi ve `pdftotext` ile tarandı. PDI ile ilgili doğrulanan maddeler:
+
+| DO-178C bölümü | DO-178B karşılığı | FAA farklar aracının söylediği |
+|---|---|---|
+| §2.5.1 Parameter Data Items | yok (N/A) | "Added: Entire Section >> Describes what a parameter data item comprises, what it contains, and what should be addressed." |
+| §4.2.j (+ j.1–j.4) | yok | Planlamada ele alınacaklar: PDI'ların **kullanım şekli**, **software level'ı**, geliştirme/doğrulama/değiştirme süreçleri ve ilgili **araç nitelendirmesi**, **software load control ve compatibility** |
+| §5.1.2 | değişiklik | "If parameter data items are planned, the high-level requirements should describe how any parameter data item is used by the software. The high-level requirements should also specify their **structure**, the **attributes** for each of their data elements, and, when applicable, the **value** of each element. The values of the parameter data item elements should be consistent with the structure of the parameter data item and the attributes of its data elements" |
+| §5.4.1a / §5.4.2 | değişiklik | Entegrasyon süreci artık PDI dosyalarını da üretir: "Any Parameter Data Item File should be generated" |
+| §6.6 Verification of Parameter Data Items | yok (N/A) | "Added: Entire Section >> Explains that if all of the following conditions are met, verification of a PDI can be conducted separately from the verification of the executable Object Code. Provides the criteria and activities needed to verify PDI files." |
+| §7.2.1.e | değişiklik | Konfigürasyon tanımlama kapsamı PDI dosyalarını içerecek şekilde genişletildi ("since they can be separate from the executable object code data item") |
+| §7.2.7.d / .e | değişiklik | Arşiv/erişim/serbest bırakma kapsamı PDI dosyalarını içerecek şekilde genişletildi |
+| §8.3.e | değişiklik | Conformity review: PDI dosyaları da arşivlenmiş kaynaktan **yeniden üretilebilmeli** |
+| §11.16 SCI | değişiklik | SCI artık build talimatlarında PDI'yı ve kullanılan PDI dosyalarının açık kimliğini içermeli (11.16g) |
+| §11.22 Parameter Data Item File | yok (N/A) | "Added: Entire Section >> Explains what a parameter data item file consists of" |
+| Tablo A-2 | değişiklik | "PDI was added to the objective relating to being loaded into the target computer" |
+| Tablo A-5 | değişiklik | "Added: Activity references, **two additional objectives** for verification of PDI file and PDI file is correct and complete." |
+| Annex B (Glossary) | yok | "Parameter Data Item" ve "Parameter Data Item File" yeni terim olarak eklendi |
+
+**Numaralandırma notu:** FAA aracı Tablo A-5'e iki objektif eklendiğini söylüyor ama numara vermiyor.
+Birden çok ikincil kaynak bunları **A-5 #8** ("Parameter Data Item File is correct and complete") ve
+**A-5 #9** (PDI dosyasının doğrulanması) diye anıyor. Yazıda bu şekilde, "yaygın numaralandırma" kaydıyla verildi.
+
+**Karşı-kontrol:** patmos-eng sayfası PDI objektiflerini "Table A-6 #6" ve "Table A-7 #9" diye veriyor.
+Bu büyük olasılıkla hatalı: A-7 #9 yaygın olarak "kaynak koda izlenemeyen ek kodun doğrulanması"
+(object code verification) objektifi olarak biliniyor — Rapita/LDRA sayfaları bunu doğruluyor.
+Bu yüzden yazıda A-6/A-7 numaraları kullanılmadı; yalnızca FAA'in doğruladığı "A-5'e iki objektif"
+ifadesi + ikincil kaynakların #8/#9 numaralandırması aktarıldı.
+
+## 2. Tanım
+
+DO-178C Annex B (ikincil kaynaklardan aktarılan sözcükler):
+"a set of data that, when in the form of a Parameter Data Item File, influence the behaviour of the
+software without modifying the Executable Object Code and that is managed as a separate
+configuration item."
+
+## 3. A400M / Sevilla vakası — doğrulanan olgular
+
+- 9 Mayıs 2015, A400M MSN023, ilk uçuş (üretim kabul uçuşu), Sevilla San Pablo yakınında
+  La Rinconada'ya düştü; 6 mürettebattan 4'ü öldü. (Wikipedia, BAAA)
+- Uçak Türk Hava Kuvvetleri'ne teslim edilecekti (Haziran 2015 planlanan). (Wikipedia)
+- Bildirilen neden: motor yazılımı Airbus tesisinde yüklenirken **üç motorda tork kalibrasyon
+  parametre verisi kazara silindi**; FADEC'ler bu parametreleri okuyamadı.
+- Airbus ifadesi: "engines one, two and three experienced power frozen after lift-off and did not
+  respond to the crew's attempts to control the power setting in the normal way."
+- Yerde kokpitte uyarı yoktu; ilk uyarı ~120 m (390 ft) irtifada geliyordu. (Wikipedia)
+- Airbus 19 Mayıs 2015'te **Alert Operator Transmission (AOT)** yayımladı: bir sonraki uçuştan önce
+  her motorun ECU'sunda bir kerelik kontrol + motor/ECU değişimi sonrası ek kontroller.
+  (Skies Mag basın bülteni, Defense News, The Register)
+- Soruşturma İspanya Silahlı Kuvvetleri kaza komisyonu **CITAAM** tarafından yürütüldü
+  (14 Mayıs 2015'te devraldı). Tam teknik rapor kamuya açık değil.
+- Bağlam: A400M **EASA sivil tip sertifikası** aldı (13 Mart 2013); TP400-D6 motorunun ayrı
+  EASA motor tip sertifikası var (EASA.E.033) ve TCDS FADEC'i "Engine Control Unit and
+  Application Software" olarak listeliyor.
+
+**Hedge:** Ayrıntı basın + Airbus açıklamalarına dayanıyor; hangi motorların (1-2-3 mü 2-3-4 mü)
+etkilendiği kaynaklar arasında tutarsız. Yazıda Airbus ifadesindeki "1, 2 ve 3" kullanıldı ve
+"kamuya açık kaynaklara göre" kaydı düşüldü.
+
+## 4. Deney (derinlik öğesi)
+
+`scratchpad/pdi/pdi_demo.c` ve `pdi_safe.c`. Ortam: Apple clang 21.0.0, arm64-apple-darwin25.5.0,
+`gcc -std=c11 -O2 -Wall -Wextra`. Çıktılar yazıya birebir kopyalandı.
+
+- `pdi_demo`: alan sırası değişmiş iki 12 baytlık struct; aynı dosya sessizce yanlış okunuyor
+  (337.50 Nm yerine −112499.88 Nm). 0xFF silinmiş bölge → NaN; 0x00 → k=0, tork her zaman 0.
+- `pdi_safe`: magic + şema + uzunluk + CRC-32 + aralık + part-number uyumu kontrol eden
+  bayt-bayt okuyucu; sekiz senaryonun yedisini reddediyor.
+- CRC-32 (0xEDB88320 ters polinom) doğrulaması: `CRC32("123456789") = 0xCBF43926` — standart
+  kontrol vektörüyle uyuşuyor.
+
+## 5. Sınır çizgisi: PDI vs DO-200B/C
+
+DO-200B (2013) / DO-200C — "Standards for Processing Aeronautical Data" (ED-76A/ED-76B).
+Premise farklı: veri işleme zinciri boyunca **veri kalitesini** korumak/kanıtlamak. Navigasyon
+veritabanları buraya girer. DO-178C PDI ise yazılımın davranışını belirleyen konfigürasyon
+verisidir ve yazılım yaşam döngüsü içinde ele alınır. İkisi karıştırılıyor.
+
+## 6. Yükleme zinciri
+
+ARINC 665 — Loadable Software Part / Media Set Part dosya formatı (header file + data files,
+Header File CRC ve Load CRC alanları). ARINC 615A — TFTP tabanlı yükleme protokolü.
+DO-178C §7.4 Software Load Control. Bunlar taşıma bütünlüğünü korur; **anlamsal** doğruluğu değil.
+
+## 7. Gizlilik kontrolü
+
+Yazının tamamı kamuya açık kaynaklardan: FAA farklar aracı (kamuya açık PDF), EASA basın
+bültenleri/TCDS, basın haberleri, ARINC/RTCA standart adları. Proje-spesifik, kurum-içi veya
+ihracat kontrollü hiçbir ayrıntı yok. Deney kodu tamamen sentetik.

--- a/agent/topics.md
+++ b/agent/topics.md
@@ -1,16 +1,17 @@
 # Konu Defteri
 
 > Otonom yazı ajanının kalıcı belleği. Her çalıştırmada okunur ve güncellenir.
+> Son senkronizasyon: **2026-08-24**
 
 ## Yazıldı (yayında)
 
 - [x] Tümleşik Gereksinim Yönetimi — 2022-04-28 — alan: sistem/gereksinim
-- [x] Yazılım Sistem Mühendisliği — 2022-04-29 — alan: sistem
+- [x] Yazılım Sistem Mühendisliği — 2022-04-30 — alan: sistem
 - [x] Use Case Tuzakları — 2022-05-01 — alan: gereksinim/analiz
-- [x] Yazılım Proje Yönetimi Pratikleri — 2022-05-03 — alan: proje yönetimi
+- [x] Yazılım Proje Yönetimi Pratikleri — 2022-05-01 — alan: proje yönetimi
 - [x] Gereksinimler ve Test: Yedi Eksik Bağlantı — 2022-05-08 — alan: gereksinim/test
 - [x] Fonksiyonel Olmayan Yazılım Gereksinimleri — 2022-07-11 — alan: gereksinim
-- [x] CMake — 2022-07-20 — alan: araçlar
+- [x] CMake — 2022-07-19 — alan: araçlar
 - [x] Elektrik Kesintisinde Otomatik Açılış — 2022-08-15 — alan: sistem
 - [x] Recursively Delete a Specific Folder — 2022-09-11 — alan: araçlar
 - [x] Merge Files with FFmpeg — 2023-03-12 — alan: araçlar
@@ -22,107 +23,95 @@
 - [x] Ölçüm Belirsizliği (GUM Annex F + NCSLI RP-12) — 2026-05-06 — alan: metroloji
 - [x] Kalibrasyon Zincirinin Tepesi (Birincil Standartlar) — 2026-05-07 — alan: metroloji
 - [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14 — alan: gömülü/SoC
+- [x] Bandpass Sampling — 2026-05-21 — alan: RF/DSP
+- [x] Sistem Mühendisliği Nedir — 2026-05-26 — alan: sistem
+- [x] Kalman Filtresi ve EKF — 2026-06-02 — alan: navigasyon/füzyon
+- [x] Coupling'i Dengelemek — 2026-06-04 — alan: yazılım tasarımı
+- [x] Antikırılgan: Belirsizlikten Güç Alan Sistemler — 2026-06-24 — alan: sistem düşüncesi
 
-## Açık PR'lar (insan inceleme bekleniyor)
-
-| PR # | Başlık | Dal | Açılış | Alan |
-|------|--------|-----|--------|------|
-| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | post/2026-05-20-crc-polinom-secimi-ve-hamming-mesafesi | 2026-05-20 | yazılım zanaatı/hata tespiti |
-| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR Geometrisi | post/2026-05-19-vor-faz-karsilastirma | 2026-05-19 | navigasyon |
-| [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A | post/2026-05-18-mcdc-kapsama-do-178c-dal-a | 2026-05-17 | sertifikasyon |
-| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi (C/C++, Rust) | post/bellek-guvenligi-devrimi | 2026-04-12 | gömülü/güvenlik |
-| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış (Undefined Behavior) | blog/undefined-behavior | 2026-04-04 | C/derleyici |
-| [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | blog/misra-c-statik-analiz | 2026-03-28 | standart/C (#69 ile çakışma riski!) |
-| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ (eski yazı genişletme) | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
-
-> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. İnceleyen kişinin dikkatine.
+**Son 3 yayın (alan rotasyonu için):** sistem düşüncesi · yazılım tasarımı · navigasyon/füzyon
 
 ## Seçildi / Devam Eden
 
-- **Bandpass Sampling: 1 GHz Sinyali 50 MHz Saatle Örneklemek** —
-  dal: `post/2026-05-21-bandpass-sampling`,
-  dosya: `_posts/2026-05-21-bandpass-sampling.md`,
-  durum: PR açılacak (bu çalıştırma) — alan: RF/DSP.
+- **Kod Doğru, Veri Yanlış: DO-178C'de Parameter Data Item** —
+  dal: `post/2026-08-24-do-178c-parameter-data-item`,
+  dosya: `_posts/2026-08-24-do-178c-parameter-data-item.md`,
+  araştırma: `agent/research/2026-08-24-do-178c-parameter-data-item.md`,
+  durum: PR açıldı — alan: sertifikasyon/konfigürasyon verisi.
 
-## Reddedildi (bu çalıştırma)
+## Bu çalıştırmanın notları (2026-08-24)
 
-- _(bu çalıştırmada konu reddedilmedi; bandpass sampling havuzdan seçildi.)_
+- **Backlog uyarısı:** repoda **55 açık PR** var ve bunların ~50'si yayınlanmamış yazı.
+  Defter en son 2026-05-21'de güncellenmişti; o tarihten sonra açılan PR'lar deftere hiç
+  işlenmemiş. Bu çalıştırmada envanter GitHub'dan yeniden çekildi. Yayın kapısı kuralı
+  (`min_yayin_araligi_gun = 2`) fazlasıyla sağlanıyor — son yayın 2026-06-24, arada iki ay var —
+  ama **darboğaz üretimde değil, insan incelemesinde.** İnceleyen kişinin dikkatine.
+- **Konu seçimi:** 24 yayınlanmış yazı + 55 açık PR başlığı taranarak anlamsal çakışma kontrolü
+  yapıldı. Fikir havuzundaki yüksek öncelikli adayların neredeyse tamamı açık PR'larla tüketilmiş
+  durumda (GIC, linker script, watchdog, WCET, MPU/MMU, volatile/_Atomic, IQ örnekleme, ILS,
+  CRC, MC/DC, sabit nokta, lockstep, endianness, DMA/cache, SEU/ECC, DO-330, DO-326A, FTA...).
+  PDI hiçbiriyle örtüşmüyor.
+- **Novelty gerekçesi:** PDI, DO-178C'de tek bir bölümde toplanmamış; kavram §2.5.1, §4.2.j,
+  §5.1.2, §5.4.1a, §6.6, §7.2.1, §7.2.7, §8.3, §11.16, §11.22 ve Annex A tablolarına dağılmış
+  durumda. Standart ücretli olduğu için sentezlenmiş kaynak yok; Türkçe içerik ise sıfır.
+  FAA'in kamuya açık "DO-178B/C Differences Tool" dokümanı bu haritayı çıkarmayı mümkün kıldı.
+- **Derinlik öğesi:** gerçek deney (Apple clang 21, arm64) + standart yorumu + arıza modu analizi.
+  İki C programı derlenip çalıştırıldı; çıktılar yazıya birebir alındı. CRC-32 uygulaması
+  `CRC32("123456789") = 0xCBF43926` standart kontrol vektörüyle doğrulandı.
+- **Reddedilenler (bu çalıştırma):** ARINC 429 anatomisi (açık PR'lardaki 1553B ve AFDX ile aynı
+  "veri yolu" ailesinde, üst üste gelir); GPS hafta numarası rollover (navigasyon — son 3 yayında
+  Kalman var, alan rotasyonu ihlali); kontrol yasası ayrıklaştırma (İngilizce ders kitaplarında
+  doygun, novelty testini geçmiyor); derleyicinin ürettiği `__aeabi_*` runtime çağrıları
+  (açık PR #146 "Object Code Coverage" ile kardeş konu, çakışma riski).
 
-## Fikir Havuzu (aday konular — gelecek çalıştırma için)
+## Açık PR'lar (insan incelemesi bekliyor) — 2026-08-24 itibarıyla 55 adet
 
-Aşağıdaki adaylar, mevcut yazılar + açık PR'larla çakışmıyor ve Bölüm 6 kriterlerini
-geçici olarak karşılıyor. Faz 2'de tekrar değerlendirilmesi gerekir.
+En eskiler öncelik sırasında: #50, #51, #54, #67, #77, #78, #79.
+Bilinen sorun: **#51 "MISRA C ve Statik Analiz"**, yayında olan "MISRA C:2025 ile Neler Değişti"
+ile büyük olasılıkla çakışıyor. Ayrıca **`volatile` konusunda altı ayrı PR var**
+(#100, #134, #155, #156, #157, #159) — bunlardan en fazla biri yayınlanmalı, kalanı kapatılmalı.
+Benzer şekilde WCET için iki PR (#88, #98, ayrıca #164) ve watchdog için iki PR (#89, #161) var.
 
-### Yüksek öncelikli (kalıcı değer + Türkçe boşluk)
+> Not: tam liste `gh pr list --repo mavrikant/mavrikant.github.io --state open` ile alınır;
+> burada tekrarlanmıyor çünkü hızla eskiyor.
 
-- [ ] **ARM Cortex-A reset vektöründen `main()`'e: gerçekten ne oluyor?** —
-      alan: gömülü/SoC — Renode yazısının doğal devamı, somut deney imkânı
-- [ ] **MC/DC kapsama: DO-178C DAL A'da neden modified condition/decision şart?** —
-      alan: sertifikasyon — gerçek karar tablosu örneği, decision/condition farkı
-- [ ] **CRC vs checksum: neden CRC-32 değil de CRC-32C / CRC-16-CCITT seçilir?** —
-      alan: yazılım zanaatı — polinom seçimi, hata tespit gücü, bit-hata analizi
-- [ ] **WCET analizi: statik analiz vs ölçüm tabanlı yaklaşımlar, cache etkileri** —
-      alan: gerçek zamanlı — somut örnek (örn. Cortex-R5 üzerinde basit görev)
-- [ ] **IQ örnekleme ve karmaşık sinyaller: gerçek SDR'ye giriş** —
-      alan: RF/SDR — neden negatif frekans, neden 2 kanal
-- [ ] **GIC (Generic Interrupt Controller): SGI/PPI/SPI farkları ve önceliklendirme** —
-      alan: ARM — kesme yönlendirme, multicore'da CPU affinity
-- [ ] **Cache coherency ve MESI: ARM'da CCI/CMN ne yapar, neden yazılım perde
-      (barrier) gerekir?** — alan: ARM — pratik race condition örneği
-- [ ] **Linker script anatomisi: ARM bare-metal için bir `.ld` dosyası satır satır** —
-      alan: gömülü — kendi linker script'i yazma rehberi
-- [ ] **Watchdog tasarım desenleri: tek vs çoklu görev watchdog, deadman switch,
-      windowed watchdog** — alan: güvenilirlik — gerçek tasarım kararları
-- [ ] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
-      alan: C/eşzamanlılık — derleyici çıktı analizi
-- [ ] **VOR'un çalışma prensibi: 30 Hz referans + değişken faz nasıl yön verir?** —
-      alan: navigasyon — faz farkı matematiği + sinyal şeması
-- [ ] **ILS anatomisi: localizer 90/150 Hz DDM ve glide slope** —
-      alan: navigasyon — modülasyon derinliği farkı + örnek hesap
-- [ ] **Kalman filtresi tuzakları: numerik stabilite, gözlemlenebilirlik, tuning** —
-      alan: navigasyon/füzyon — basit IMU örneği + Python kodu
-- [ ] **Sabit nokta (Q-format) aritmetik: Cortex-M0'da FPU yokken DSP nasıl yapılır?** —
-      alan: gömülü/DSP — Q15/Q31 örnekleri, overflow yönetimi
+## Fikir Havuzu (açık PR'larla çakışmayan kalan adaylar)
 
-### Orta öncelikli (kovaya alındı)
+### Yüksek öncelikli
 
-- [ ] DO-330 araç nitelendirme (Tool Qualification) seviyeleri
+- [ ] **ARINC 429 anatomisi** — 32-bit kelime, label'ın sekizlik gösterimi, SDI/SSM anlambilimi,
+      BNR/BCD, çözünürlük hesabı — *1553B/AFDX PR'ları merge edildikten sonra*
+- [ ] **Kontrol yasası ayrıklaştırma tuzakları** — Tustin vs Euler, integrator windup,
+      bumpless transfer — *novelty açısı güçlendirilmeli*
+- [ ] **libc yeniden girişli değildir** — newlib `_impure_ptr`, `errno`, `__malloc_lock`,
+      ISR'den `printf` — alan: gömülü/C çalışma zamanı
+- [ ] **GPS hafta numarası rollover (WNRO)** — 10-bit hafta, 1999/2019 olayları, pivot yıl
+      çözümü, CNAV 13-bit — alan: navigasyon/zaman
+- [ ] **Dead code vs deactivated code vs extraneous code** — DO-178C §6.4.4.3 yorum belirsizliği
+- [ ] **AAPCS/EABI yığın hizalaması** — ISR'de 8 bayt hizalama ihlalinin sessiz sonuçları
+- [ ] **IIR katsayı kuantizasyonu** — sabit noktada kutup göçü ve stabilite kaybı
+- [ ] **ARM PMU ile kesme gecikmesi ölçmek** — çevrim sayacı okumanın tuzakları
+
+### Orta öncelikli
+
+- [ ] DO-331 model tabanlı geliştirme ve otomatik kod üretiminin sertifikasyon kredisi
 - [ ] ARP4754A — sistem geliştirme süreci
-- [ ] DO-326A / ED-202A havacılık siber güvenliği
 - [ ] FMEA pratikte: gerçek bir alt-sistem üzerinden adım adım
-- [ ] Fault Tree Analysis ile minimal cut set hesabı
-- [ ] FPU denormal performansı: Cortex-A vs x86 davranış farkı
-- [ ] Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain
-- [ ] Endianness: ağ baytı vs host baytı, ARM'ın iki modu, bitfield tuzakları
-- [ ] DMA yarış koşulları: ARM'da cache invalidation/clean stratejileri
-- [ ] Lockstep CPU mimarisi: TI Hercules / NXP MPC57xx örnekleri
-- [ ] MPU vs MMU: hangisi ne zaman, FreeRTOS-MPU örneği
-- [ ] Statik analiz neyi yakalar / kaçırır: somut C kodu üzerinden Coverity/Polyspace
-- [ ] Radyasyona dayanıklı yazılım: SEU, TMR, scrubbing
+- [ ] IEEE 1588 PTP / TTEthernet — aviyonikte zaman senkronizasyonu
+- [ ] Cyclic executive vs preemptive: aviyonikte neden hâlâ döngüsel çizelge
 - [ ] ADS-B sinyal yapısı: PPM modülasyon, mesaj formatı
 - [ ] FIR vs IIR: faz cevabı, hesaplama maliyeti, stabilite
+- [ ] Robustness test case tasarımı: eşdeğerlik sınıfı ve sınır değer analizi
 
-### Düşük öncelikli / sonraya bırak
+### Düşük öncelikli
 
 - [ ] ECSS uzay yazılım standartları ailesi (geniş, alt-konulara bölünmeli)
 - [ ] DO-254 donanım sertifikasyonu (yazarın uzmanlığı ağırlıklı yazılım tarafında)
 - [ ] İzlenebilirlik matrisi (klasik konu, derinlik çıkarmak zor)
 
-## Notlar (bu çalıştırma — 2026-05-21)
+## Reddedildi (kalıcı kayıt)
 
-- **Bandpass Sampling** seçildi (alan: RF/DSP). Önceki çalıştırmaların ardından
-  açılan PR'lar son üç alt-alanı (sertifikasyon #77, navigasyon #78, yazılım
-  zanaatı/CRC #79) işaretlemişti; bu yazı **bu üç alandan da** son yayınlanan 3
-  posttan da (Renode gömülü/SoC, kalibrasyon ×2) farklı bir alan getiriyor.
-- Yayın kapısı durumu: Bölüm 4 yalnızca "yayın PR ile olmalı" kuralı koyar; backlog
-  büyüklüğüne dair sert bir sınır yoktur. Açık 7 PR olmasına rağmen son yayınlanan
-  yazıdan (Renode, 2026-05-14) bu yana 7 gün geçti — `min_yayin_araligi_gun = 2`
-  şartı fazlasıyla sağlanmış durumda. Bu çalıştırmada yeni PR açıldı.
-- Bandpass sampling konusunun "neden Türkçe içerikte zor bulunuyor" yanıtı:
-  matematik (Vaughan 1991), datasheet okuma (analog input BW), saat phase noise
-  ve filtre tasarımı disiplinlerinin kesişiminde bulunuyor; Türkçe kaynaklar
-  genellikle yalnızca tek bir cepheden ele almış oluyor (genelde Lyons özet
-  çevirisi). Sentez ve somut sayısal örnek boşluğu büyük.
-- Açık PR'lar konusunda inceleme önceliği yorumu (gözlem): #50 ve #51 hâlâ uzun
-  süredir bekliyor; #50 eski yazıyı genişletiyor, #51 ise yayındaki MISRA C:2025
-  ile büyük olasılıkla çakışıyor. İnceleyen kişinin dikkatine.
+- ARINC 429 — 2026-08-24 — açık PR'lardaki 1553B/AFDX ile aynı aile, üst üste gelir (ertelendi)
+- GPS WNRO — 2026-08-24 — alan rotasyonu: son 3 yayında navigasyon var (ertelendi)
+- Kontrol yasası ayrıklaştırma — 2026-08-24 — İngilizce literatürde doygun, novelty zayıf
+- `__aeabi_*` runtime çağrıları — 2026-08-24 — açık PR #146 ile kardeş konu, çakışma riski


### PR DESCRIPTION
## Konu ve neden seçildi

**Kod Doğru, Veri Yanlış: DO-178C'de Parameter Data Item (PDI)** — alan: sertifikasyon / konfigürasyon verisi.

24 yayınlanmış yazı ve **55 açık PR** başlığı taranarak anlamsal çakışma kontrolü yapıldı. Fikir havuzundaki yüksek öncelikli adayların neredeyse tamamı açık PR'larla tüketilmiş durumda (GIC, linker script, watchdog, WCET, MPU/MMU, `volatile`, IQ örnekleme, ILS, CRC, MC/DC, sabit nokta, lockstep, endianness, DMA/cache, SEU/ECC, DO-330, DO-326A, FTA…). PDI bunların hiçbiriyle örtüşmüyor.

Alan rotasyonu: son üç yayın sistem düşüncesi (Antikırılgan), yazılım tasarımı (Coupling) ve navigasyon/füzyon (Kalman) alanlarındaydı; bu yazı üçünden de farklı.

## "Bu konu neden az bulunuyor?"

PDI'ın DO-178C'de tek bir bölümü yok. Kavram §2.5.1, §4.2.j, §5.1.2, §5.4.1a, §6.6, §7.2.1.e, §7.2.7, §8.3.e, §11.16, §11.22 ve Annex A tablolarına dağılmış durumda. Standart ücretli olduğu için sentezlenmiş bir kaynak yok — İngilizce kaynakların çoğu eğitim şirketlerinin pazarlama sayfaları, Türkçe içerik ise pratikte sıfır. Yazının haritası, FAA'in **kamuya açık** "DO-178B/C Differences Tool" dokümanı indirilip taranarak çıkarıldı.

## Derinlik öğesi (Bölüm 7)

Üç öğe birden: **deney + standart yorumu + arıza modu analizi.**

İki C programı gerçekten derlenip çalıştırıldı (Apple clang 21.0.0, `arm64-apple-darwin25.5.0`, `gcc -std=c11 -O2 -Wall -Wextra`); yazıdaki tüm çıktılar birebir kopyadır:

1. **`pdi_demo`** — alan sırası değişmiş iki 12 baytlık struct, aynı dosyayı sessizce farklı okuyor: beklenen **337.50 Nm** yerine **−112499.88 Nm**, hiçbir hata sinyali yok. Silinmiş flash (`0xFF`) → `NaN`; sıfırlanmış bölge (`0x00`) → `k = 0` ve **her ham okumada kalıcı sıfır tork**. Hexdump ile bit deseni açıklanıyor (`0x3E000000` = `0.125f`, `0xC2160000` = `-37.5f`).
2. **`pdi_safe`** — magic + şema + uzunluk + CRC-32 + aralık + part-number uyumu kontrol eden bayt-bayt okuyucu; sekiz senaryonun yedisini gerekçesiyle reddediyor. CRC-32 uygulaması standart kontrol vektörüyle doğrulandı: `CRC32("123456789") = 0xCBF43926`.

Yazıda ayrıca bir emniyet-kritik kodlama ayrıntısı somutlaştırılıyor: aralık kontrolünün `if (!(k > lo && k < hi))` biçiminde yazılması `NaN`'ı eler, `if (k < lo || k > hi)` biçimi ise **kabul eder**.

## Doğrulama durumu

- `bundle exec jekyll build` yerelde başarıyla çalıştı (Ruby 3.2, yalnızca mevcut Sass deprecation uyarıları).
- Üretilen HTML kontrol edildi: mermaid bloğu mevcut yazılardaki kodlamayla aynı, tablolar ve `§` karakterleri sağlam.
- Front matter mevcut yazıların şemasıyla birebir; `date` saati erken (06:00) seçildi — deploy'un `--future` kullanmaması nedeniyle.

## Kaynaklar

- FAA/AVS **DO-178B/C Differences Tool** Rev. 010 (15.03.2014) — PDI'ın DO-178C'ye giren bölümlerinin madde madde listesi (birincil dayanak)
- RTCA DO-178C / EUROCAE ED-12C (ücretli birincil standart)
- 2015 Sevilla A400M kazası: Wikipedia, Airbus AOT basın bülteni (19.05.2015), The Register
- EASA A400M tip sertifikası (13.03.2013), EASA.E.033 TP400-D6 motor tip sertifikası
- DO-200B / ED-76A, AdaCore SPARK PDI demo, Rapita (Tablo A-7 karışıklığını ayırt etmek için)

Ayrıntılı araştırma notları ve kaynak-kaynak doğrulama izi: `agent/research/2026-08-24-do-178c-parameter-data-item.md`

## Öz-eleştiri özeti (Faz 6)

- **Numaralandırma riski.** FAA dokümanı Tablo A-5'e "iki ek objektif" eklendiğini söylüyor ama numara vermiyor; ikincil kaynaklar bunları #8/#9 diye anıyor. Yazı bu numaraları **"yaygın numaralandırma" kaydıyla** veriyor ve `patmos-eng`'in A-6/A-7 iddiasının neden büyük olasılıkla hatalı olduğunu (A-7 #9 yaygın olarak object code verification objektifidir) açıkça not ediyor.
- **Kaza anlatımı hedge edildi.** CITAAM'ın tam teknik raporu kamuya açık değil; hangi motorların etkilendiği kaynaklar arasında tutarsız (1-2-3 vs 2-3-4). Yazı Airbus ifadesindeki "1, 2 ve 3"ü kullanıyor ve ayrıntıların "kesin sebep" değil **kamuya açık kaynakların anlattığı senaryo** olduğunu açıkça söylüyor.
- **Sınır netleştirildi.** PDI ile DO-200B/C aeronautical data sürekli karıştırıldığı için ayrı bir bölüm eklendi.
- **Gizlilik.** Yazının tamamı kamuya açık kaynaklardan; deney kodu tamamen sentetik. Proje-spesifik, kurum-içi veya ihracat kontrollü hiçbir ayrıntı yok.

---

## ⚠️ Backlog uyarısı (yazıdan bağımsız)

Bu çalıştırmada envanter GitHub'dan yeniden çekildi: **55 açık PR** var ve bunların ~50'si yayınlanmamış yazı. `agent/topics.md` defteri 2026-05-21'den beri güncellenmemişti; bu PR defteri gerçek durumla senkronize ediyor. Darboğaz üretimde değil, insan incelemesinde. İncelerken işe yarayabilecek gözlemler:

- **`volatile` konusunda altı ayrı PR var** (#100, #134, #155, #156, #157, #159) — en fazla biri yayınlanmalı.
- WCET için üç PR (#88, #98, #164), watchdog için iki PR (#89, #161).
- **#51 "MISRA C ve Statik Analiz"**, yayında olan "MISRA C:2025 ile Neler Değişti" ile büyük olasılıkla çakışıyor.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)