### PR TITLE
Yeni yazı: Python'da Çalışan Filtre Hedefte Neden Patlıyor? IIR Katsayı Kuantizasyonu

### DIFF
--- a/_posts/2026-08-25-iir-katsayi-kuantizasyonu-kutup-gocu.md
+++ b/_posts/2026-08-25-iir-katsayi-kuantizasyonu-kutup-gocu.md
@@ -1,0 +1,281 @@
+---
+title: "Python'da Çalışan Filtre Hedefte Neden Patlıyor? IIR Katsayı Kuantizasyonu"
+subtitle: "Coefficient Quantization, Pole Migration and Why Your High-Order IIR Filter Explodes"
+background: "/img/posts/2.webp"
+date: '2026-08-25 07:30:00'
+layout: post
+lang: tr
+mermaid: true
+categories: [aviyonik]
+tags: [sinyal-isleme, gomulu-sistemler]
+---
+
+Filtreyi masaüstünde tasarlarsınız. `butter(8, 100/5000)` yazarsınız, frekans cevabına bakarsınız, geçirme bandı düz, durdurma bandı 80 dB aşağıda. Kesim frekansı tam istediğiniz yerde. Katsayıları bir başlık dosyasına dökersiniz, hedef karta gömersiniz, ve filtre çıkışı birkaç saniye içinde doygunluğa gider. Girişte hiçbir şey yokken bile.
+
+İlk şüpheniz aritmetik olur: taşma vardır, ölçekleme yanlıştır, `int16` yerine `int32` biriktirici kullanmak gerekir. Bunların hepsini düzeltirsiniz, filtre yine patlar. Çünkü sorun aritmetikte değil. Sorun, hedefe indirdiğiniz **katsayıların artık tasarladığınız filtreyi tarif etmemesinde**.
+
+Bu yazıda tam olarak bunu ölçeceğiz. 8. dereceden bir Butterworth alçak geçiren filtre tasarlayıp katsayılarını 16 bite yuvarlayacağız, kutupların birim çemberin dışına nereye kaçtığını bulacağız, sonra "daha çok bit atalım" refleksinin neden işe yaramadığını göreceğiz — 32 bit sabit nokta ve `float32`, ikisi de kararsız çıkacak. Ardından aynı filtreyi kaskad biquad olarak gerçekleyip **aynı 16 bitle** kararlı hale getireceğiz. Bütün deney saf Python ile, harici kütüphane olmadan tekrar üretilebilir; kararlılık kararını kayan noktaya güvenmeden, kesin rasyonel aritmetikle vereceğiz.
+
+---
+
+## Tasarım ile Gerçekleme Aynı Şey Değil
+
+Sayısal filtre derslerinin çoğu transfer fonksiyonunda biter:
+
+$$
+H(z) = \frac{b_0 + b_1 z^{-1} + \cdots + b_N z^{-N}}{1 + a_1 z^{-1} + \cdots + a_N z^{-N}}
+$$
+
+Bu ifade filtreyi matematiksel olarak tam tanımlar. Ama bir filtreyi *çalıştırmak* için transfer fonksiyonu yetmez; onu bir **yapıya** (structure) dökmeniz gerekir: hangi çarpmayı hangi sırayla yapacaksınız, ara sonuçları nerede tutacaksınız, hangi sayıyı hangi formatta saklayacaksınız. Aynı $H(z)$'yi sonsuz farklı yapıyla gerçekleyebilirsiniz.
+
+Sonsuz hassasiyette bu yapıların hepsi birbirine denktir. Sonlu kelime uzunluğunda **değildir**. Ve aradaki fark akademik bir incelik değil; kararlı bir filtre ile kararsız bir filtre arasındaki fark.
+
+En doğrudan yapı, fark denklemini olduğu gibi yazmaktır — *direct form*:
+
+$$
+y[n] = \sum_{i=0}^{N} b_i\,x[n-i] \;-\; \sum_{i=1}^{N} a_i\,y[n-i]
+$$
+
+$N=8$ için bu, sekiz adet $a_i$ katsayısını doğrudan bellekte tutmak demektir. İşte kırılma noktası burası.
+
+---
+
+## Deney: 8. Dereceden Butterworth
+
+Somut ve sıradan bir filtre seçelim — aviyonikte ya da herhangi bir veri toplama zincirinde her gün karşınıza çıkacak türden:
+
+| Parametre | Değer |
+|---|---|
+| Tip | Butterworth alçak geçiren |
+| Derece | 8 |
+| Örnekleme frekansı $f_s$ | 10 kHz |
+| Kesim frekansı $f_c$ | 100 Hz |
+| $f_c / f_s$ | 0,01 |
+
+Dar kesim frekansı bu işin kritik tarafı: $f_c/f_s$ küçüldükçe kutuplar $z=1$ noktasının etrafında sıkışır. Bizim tasarımımızda sekiz kutbun tamamı $0{,}94 < |z| < 0{,}99$ aralığında, hepsi dar bir yayda toplanmış durumda.
+
+Filtreyi kütüphanesiz tasarlamak zor değil. Butterworth prototipinin analog kutupları kapalı formda bilinir, bilinear dönüşüm de tek satırlık bir işlem:
+
+```python
+import math, cmath
+
+def digital_poles(N, fc, fs):
+    Wc = 2*fs*math.tan(math.pi*fc/fs)          # prewarp
+    sp = [cmath.exp(1j*(math.pi/2 + (2*k+1)*math.pi/(2*N))) for k in range(N)]
+    return [(2*fs + Wc*s)/(2*fs - Wc*s) for s in sp]   # bilinear
+
+def poly(roots):                                # kokleri katsayiya ac
+    c = [1+0j]
+    for r in roots:
+        n = [0j]*(len(c)+1)
+        for i, ci in enumerate(c):
+            n[i] += ci; n[i+1] -= ci*r
+        c = n
+    return [x.real for x in c]
+```
+
+Payda katsayıları şöyle çıkıyor:
+
+```text
+a[0] =   1.000000
+a[1] =  -7.677940
+a[2] =  25.797220
+a[3] = -49.541226
+a[4] =  59.476132
+a[5] = -45.708734
+a[6] =  21.960120
+a[7] =  -6.030172
+a[8] =   0.724601
+```
+
+Bu tabloya bir mühendis gözüyle bakın. En büyük katsayı **59,48**. Bu sayıyı 16 bitlik işaretli bir tamsayıya sığdırmak için 6 tamsayı biti ayırmanız gerekiyor. İşaret biti bir tane. Geriye kesir için **9 bit** kalıyor.
+
+Yani katsayılarınızın çözünürlüğü $2^{-9} \approx 0{,}00195$. Kutuplarınız ise $|z| = 0{,}9878$ gibi bir yerde, birim çembere 0,012 uzaklıkta duruyor. Çözünürlüğünüz, kararlılık payınızın altıda biri kadar. Bu oranı gördüğünüz anda alarm çalmalı.
+
+---
+
+## 16 Bit: Filtre Patlıyor
+
+Katsayıları Q6.9 formatına yuvarlayıp kutupları tekrar hesaplayalım:
+
+```text
+Kutuplar (tam hassasiyet)  : max|z| = 0.987824   -> kararli
+Kutuplar (16-bit katsayi)  : max|z| = 1.433359   -> KARARSIZ
+Birim cember disina cikanlar: 1.43336, 1.43336, 1.18017, 1.18017
+```
+
+Sekiz kutbun dördü birim çemberin dışına fırladı. Bir tanesi $|z| = 1{,}43$'e kadar gitti — bu, "sınırda kararsız" değil, her örnekte genliği %43 büyüten bir kutup.
+
+Kök bulmanın kendisi bu tür ill-conditioned polinomlarda güvenilmez olabileceği için, kararsızlığı kök bulmaya hiç başvurmadan da doğrulayalım. Fark denklemini doğrudan koşturup dürtü yanıtına bakmak tartışmaya kapalı bir delildir — katsayılar kuantize, aritmetik `float64`:
+
+| Gerçekleme | `|y[1000]|` | `|y[2999]|` |
+|---|---|---|
+| float64 (tam hassasiyet) | 4,69 × 10⁻⁸ | 2,13 × 10⁻¹⁸ |
+| 16-bit sabit nokta | 7,76 × 10¹⁴⁷ | taşma (NaN) |
+
+Tam hassasiyetli filtre dürtüden sonra düzgünce sönümleniyor. 16 bitlik olan bin örnekte $10^{147}$'ye ulaşıp iki bin örnek daha sonra çift duyarlıklı kayan noktayı bile taşırıyor. Gerçek donanımda bu, filtre çıkışının bir saniyeden kısa sürede doygunluğa oturması demek.
+
+Üçüncü ve en sağlam doğrulama yöntemi **Schur-Cohn** testidir: polinomdan yansıma katsayılarını ($k_i$) özyinelemeli olarak üretir ve filtre ancak tüm $\lvert k_i \rvert < 1$ ise kararlıdır. Kök bulmaya gerek yok, ve `fractions.Fraction` ile **kesin rasyonel aritmetikte** çalıştırılabilir — yani yuvarlama hatasının sonucu etkileme ihtimali sıfır:
+
+```python
+from fractions import Fraction as Fr
+
+def stable(a):                      # a[0] == 1
+    a = [Fr(x) for x in a]; n = len(a)-1
+    while n > 0:
+        k = a[n]
+        if abs(k) >= 1: return False
+        d = 1 - k*k
+        a = [(a[i] - k*a[n-i])/d for i in range(n)]
+        n -= 1
+    return True
+```
+
+Üç yöntem de aynı sonucu veriyor: 16 bitte bu filtre kararsız.
+
+---
+
+## Neden? Wilkinson'ın Uyarısı
+
+Buradaki olgu sinyal işlemeye özgü değil; sayısal analizin en bilinen tuzaklarından biri.
+
+James Wilkinson 1963'te, kökleri 1'den 20'ye kadar olan tamsayılar olan bir polinom aldı ve $x^{19}$ katsayısını $2^{-23}$ kadar — milyarda bir mertebesinde — değiştirdi. Kökler yerinden oynamakla kalmadı, bazıları karmaşık düzleme dağıldı; $x=20$ kökü 20,8'e kaydı. Wilkinson bunu kariyerindeki en sarsıcı deneyim olarak anlatır. Çıkardığı sonuç bizim için doğrudan geçerli: **monom katsayıları, kökleri birbirine yakın olan bir polinomu temsil etmenin son derece kötü koşullanmış bir yoludur.**
+
+Direct form'un payda katsayıları tam olarak bu temsildir. $a_1 \ldots a_8$, kutupların monom açılımıdır. Kutuplar sıkışık olduğunda — bizim filtrede hepsi dar bir yayda — katsayıdaki minik bir bozulma köklerde büyük bir yer değiştirmeye dönüşür.
+
+İki etki üst üste biniyor ve ikisi de aynı yöne çalışıyor:
+
+1. **Duyarlılık:** Kutuplar sıkışık olduğu için $\partial z_i / \partial a_k$ türevleri büyük. Küçük katsayı hatası, büyük kutup göçü.
+2. **Tamsayı biti vergisi:** Katsayılar $\pm 59$ aralığına yayıldığı için sabit noktada 6 biti tamsayı kısmına ayırmak zorundasınız. Yani duyarlılığın en yüksek olduğu yerde, çözünürlüğünüz en düşük.
+
+Derece arttıkça her iki etki de kötüleşir. Aynı $f_c/f_s = 0{,}01$ için 16 bitte dereceyi tarayalım (kesin Schur-Cohn testi):
+
+| Derece | `max|a|` | Kesir biti | Sonuç |
+|---|---|---|---|
+| 2 | 1,91 | 14 | kararlı |
+| 3 | 2,87 | 13 | kararlı |
+| 4 | 5,52 | 12 | **kararsız** |
+| 5 | 9,21 | 11 | **kararsız** |
+| 6 | 17,69 | 10 | **kararsız** |
+| 8 | 59,48 | 9 | **kararsız** |
+
+Sınır 8. derecede değil. **4. derecede.** Yani "yüksek dereceli filtre" diye düşündüğünüz eşik, sandığınızdan çok daha aşağıda.
+
+---
+
+## "Daha Çok Bit Atalım" Neden Kurtarmıyor
+
+Bu noktada refleks bellidir: 16 bit yetmiyorsa 32 bit kullanırız. Ölçelim. Kelime uzunluğunu tarayıp her birinde kesin kararlılık testini çalıştıralım:
+
+| Katsayı formatı | Kesir biti | Kararlılık |
+|---|---|---|
+| 16 bit sabit nokta | 9 | kararsız |
+| 20 bit sabit nokta | 13 | kararsız |
+| 24 bit sabit nokta | 17 | kararsız |
+| 28 bit sabit nokta | 21 | kararsız |
+| **32 bit sabit nokta** | 25 | **kararsız** |
+| 40 bit sabit nokta | 33 | kararlı |
+| **`float32`** | 24 bit mantis | **kararsız** |
+| `float64` | 53 bit mantis | kararlı |
+
+İki satır burada özellikle önemli.
+
+**32 bit sabit nokta hâlâ kararsız.** Kelime uzunluğunu ikiye katlamak bu filtreyi kurtarmıyor. Kararlılık ancak 40 bit civarında geliyor — ki bu, standart bir gömülü veri tipi değil.
+
+**`float32` kararsız.** Bu, sahada en sık rastlanan tuzak. Cortex-M4F ya da M7 üzerinde tek duyarlıklı FPU'nuz var, `float` kullanıyorsunuz, sabit nokta ölçekleme derdinden kurtulduğunuzu düşünüyorsunuz. Ama `float32`'nin 24 bitlik mantisi, 59,48 büyüklüğündeki bir katsayıda yaklaşık $3{,}8 \times 10^{-6}$ mutlak çözünürlük demek — ve bu filtre için yeterli değil. Dürtü yanıtı ölçümü doğruluyor: `float32` direct form, bin örnekte $9{,}1 \times 10^{49}$'a ulaşıyor.
+
+Bir ayrıntı daha var ve dürüst olmak gerekirse rahatsız edici: tabloda kararsızlık **tekdüze azalmıyor**. Yansıma katsayısının en büyük mutlak değeri 20 bitte 1,0106 iken 24 bitte 1,0701'e *yükseliyor*, sonra 32 bitte 1,0077'ye düşüyor. Yuvarlama, katsayıları rastgele bir yöne itiyor; bazen şanslısınız, bazen değil. Pratik sonucu şu: **bit ekleyerek bu problemi güvenilir biçimde çözemezsiniz.** Bir kelime uzunluğunda kararlı çıkması, bir sonrakinde de kararlı olacağının garantisi değil. Yapıyı değiştirmeniz gerekiyor.
+
+---
+
+## Çözüm: Kaskad Biquad
+
+Standart çözüm, filtreyi tek bir 8. dereceden polinom olarak değil, dört adet 2. dereceden bölümün kaskadı olarak gerçeklemek — *second-order sections* (SOS):
+
+$$
+H(z) = \prod_{k=1}^{4} \frac{b_{0k} + b_{1k} z^{-1} + b_{2k} z^{-2}}{1 + a_{1k} z^{-1} + a_{2k} z^{-2}}
+$$
+
+<div class="mermaid">
+flowchart LR
+    X[x n] --> B1[Biquad 1] --> B2[Biquad 2] --> B3[Biquad 3] --> B4[Biquad 4] --> Y[y n]
+</div>
+
+Her bölüm bir eşlenik kutup çiftini taşır. Aynı filtreyi, **aynı 16 bitle** böyle gerçekleyelim:
+
+```text
+biquad 1: a1 = -1.880260  a2 = 0.883977   F=14  kararli
+biquad 2: a1 = -1.897013  a2 = 0.900764   F=14  kararli
+biquad 3: a1 = -1.928769  a2 = 0.932583   F=14  kararli
+biquad 4: a1 = -1.971898  a2 = 0.975797   F=14  kararli
+```
+
+Kutup hataları da beşinci ondalık basamakta kalıyor — örneğin en kritik bölümde tam değer $0{,}987824$, kuantize değer $0{,}987810$.
+
+Kelime uzunluğu değişmedi. Filtrenin matematiği değişmedi. Değişen tek şey, katsayıların hangi biçimde saklandığı. Peki neden bu kadar büyük fark yarattı?
+
+**Birincisi, tamsayı biti vergisi ortadan kalktı.** Bir biquad'ın payda katsayıları için kararlılık üçgeni $\lvert a_2 \rvert < 1$ ve $\lvert a_1 \rvert < 1 + a_2 < 2$ sınırlarını dayatır. Yani hiçbir kararlı biquad'ın katsayısı 2'yi aşamaz. Tek tamsayı biti yeter, kesir için **14 bit** kalır. Direct form'daki 9 bite kıyasla LSB 32 kat daha ince.
+
+**İkincisi ve daha önemlisi, hata yayılmıyor.** Direct form'da $a_3$'ü yuvarladığınızda sekiz kutbun *hepsi* birden yerinden oynar; kökler katsayılara topluca bağlıdır. Kaskadda 3. bölümün katsayısını yuvarladığınızda yalnızca o bölümün kutup çifti oynar, diğer altı kutup zerre kadar etkilenmez. Wilkinson'ın uyarısına dönersek: kaskad yapı, polinomu monom katsayılarıyla değil **çarpanlarıyla** temsil eder, ve çarpanlanmış temsil iyi koşullanmıştır.
+
+---
+
+## Direct Form I mi, II mi, Transpoze mi?
+
+Kaskada geçtiğinizde ikinci bir seçim çıkar: her biquad'ın içini nasıl yazacaksınız? Bu tercih katsayı kuantizasyonuyla değil, **ara değerlerin dinamik aralığıyla** ilgilidir; ayrı bir konudur ama aynı yazının parçasıdır.
+
+- **Direct Form I** girişleri ve çıkışları ayrı ayrı geciktirir; dört durum değişkeni tutar. Ara toplam tek bir biriktiricide oluşur, dolayısıyla geniş biriktiriciyle taşma kontrolü kolaydır.
+- **Direct Form II** durum sayısını ikiye indirir ama iç düğümde, payda filtresinin çıkışında, giriş ve çıkışın ikisinden de daha büyük genlikler oluşabilir. Sabit noktada bu, görünmez bir taşma kaynağıdır.
+- **Transposed Direct Form II** kayan noktada yaygın ve iyi davranışlıdır, fakat durum değişkenleri için yine geniş dinamik aralık ister.
+
+Bu tercihin sektörde nasıl karara bağlandığını görmek için ARM'ın CMSIS-DSP kütüphanesinin API'sine bakmak yeterli. Kütüphane biquad kaskadı için üç aile sunar ve veri tipi desteği tesadüf değildir: Direct Form I ailesi Q15 ve Q31'i destekler, çünkü dokümantasyonun kendi ifadesiyle DF-I sabit nokta veri tipleri için sayısal olarak daha gürbüzdür. Transposed Direct Form II ailesinde ise yalnızca `float32` ve `float64` vardır — hata birikimi nedeniyle sabit nokta sürümü hiç sağlanmamıştır.
+
+Daha çarpıcı olan, kütüphanede **olmayan** şey: CMSIS-DSP'de keyfi dereceden direct form IIR fonksiyonu hiç yoktur. Özyinelemeli filtre için sunulan tek seçenekler kaskad biquad aileleri ve lattice yapısıdır — ki lattice de katsayı duyarlılığı düşük olduğu bilinen bir yapıdır. Bu yazıda ölçtüğümüz sonuç, ARM'ın API tasarımına çoktan gömülmüş durumda.
+
+---
+
+## Pratik Notlar
+
+Deneyden çıkan ve doğrudan uygulanabilir birkaç sonuç:
+
+**Filtreyi baştan SOS olarak üretin.** Tasarım aracınızdan `[b, a]` isteyip sonra çarpanlarına ayırmak, kötü koşullanmış adımı sadece masaüstüne taşır. SciPy bunu dokümantasyonunda açıkça söyler: `output='ba'` yalnızca geriye dönük uyumluluk için varsayılandır, genel amaçlı filtreleme için `output='sos'` kullanılmalıdır, çünkü kökler ile polinom katsayıları arasındaki dönüşüm $N \ge 4$ için bile sayısal olarak hassas bir işlemdir. Aynı eşik bizim ölçümümüzde de çıktı.
+
+**4. dereceyi bir eşik olarak kabul edin.** İki biquad'ı geçen her IIR filtresi, sabit noktada kaskad olarak gerçeklenmeli. "Sadece 4. derece, direct form yeterli" varsayımı bu deneyde yanlış çıktı.
+
+**`float32` sizi kurtarmaz.** Kayan noktaya geçmek ölçekleme derdini azaltır, koşullandırma problemini çözmez. Kaskad yapı hem sabit noktada hem `float32`'de gereklidir.
+
+**Bölüm sıralaması ve ölçekleme önemlidir.** Kaskadda hangi kutup çiftinin hangi sıfır çiftiyle eşleştirileceği ve bölümlerin hangi sırayla dizileceği, taşma ile gürültü tabanı arasındaki dengeyi belirler. Yaygın kural: birim çembere en yakın kutup çiftini en sona koyun, ve her kutup çiftini kendisine en yakın sıfır çiftiyle eşleştirin. Bu, ara düğümlerdeki tepe genliklerini düşürür.
+
+**Kararlılığı sembolik olarak değil, kuantize katsayılarla doğrulayın.** Tasarım aracınızın gösterdiği kutuplar, hedefe indireceğiniz katsayıların kutupları değildir. Doğrulama adımını başlık dosyasındaki *gerçek* sayılar üzerinde yapın — yukarıdaki 20 satırlık Schur-Cohn fonksiyonu bunun için yeterlidir ve derleme öncesi bir betikte çalıştırılabilir.
+
+**Kuantizasyon kararlılığı bitirmez, sadece başlangıcıdır.** Bu yazı yalnızca *katsayı* kuantizasyonunu ölçtü. Sabit noktada ikinci bir problem daha var: sinyal yolundaki yuvarlama, giriş sıfır olduğu halde çıkışta sönmeyen küçük salınımlar üretebilir — *limit cycle*. Kaskad yapı bunu da hafifletir ama tamamen ortadan kaldırmaz; ayrı bir analiz konusudur.
+
+---
+
+## Deneyi Kendiniz Koşturun
+
+Yazıdaki bütün sayılar tek bir bağımlılıksız Python betiğinden çıktı. Üç bağımsız yöntem aynı sonuca varıyor: Durand-Kerner ile kök bulma, kesin rasyonel aritmetikte Schur-Cohn testi, ve zaman düzleminde dürtü yanıtı. Kök bulucunun kendisi de doğrulandı — bulunan kökler yeniden çarpanlanıp giriş katsayılarıyla karşılaştırıldığında hata $3 \times 10^{-11}$ mertebesinde kaldı.
+
+Parametreleri değiştirip kendi filtrenizde deneyin. Özellikle $f_c/f_s$ oranını küçültün: 0,001'e indirdiğinizde kaskadın bile zorlanmaya başladığını göreceksiniz, ve o noktada tartışma artık yapı seçiminden çıkıp örnekleme hızını düşürmeye ya da çok kademeli desimasyona geçer.
+
+---
+
+## Sonuç
+
+Bir filtre tasarımı iki ayrı karardır ve ikincisi genellikle atlanır. Transfer fonksiyonunu seçmek tasarımın yarısıdır; onu hangi yapıyla, hangi sayı formatında gerçekleyeceğinizi seçmek diğer yarısıdır. Masaüstünde `float64` ile çalışırken bu ikinci karar görünmezdir, çünkü 53 bitlik mantis bütün günahları örter. Hedefte örtmez.
+
+Ölçtüğümüz somut sonuç şu: 8. dereceden, $f_c/f_s = 0{,}01$ olan sıradan bir Butterworth filtresi, direct form'da 16 bitle de, 32 bitle de, `float32` ile de kararsız. Aynı filtre, dört kaskad biquad olarak, 16 bitle kararlı ve kutup hatası beşinci ondalıkta.
+
+Kelime uzunluğu meselesi değil. Temsil meselesi.
+
+---
+
+## Kaynaklar
+
+- [Wilkinson's polynomial — Wikipedia](https://en.wikipedia.org/wiki/Wilkinson%27s_polynomial) — kökleri sıkışık polinomlarda monom katsayı temsilinin kötü koşullanması
+- [Cleve Moler, "Wilkinson's Polynomials" — MATLAB Central](https://blogs.mathworks.com/cleve/2013/03/04/wilkinsons-polynomials/) — problemin sayısal analiz açısından anlatımı
+- [`scipy.signal.butter` — SciPy Manual](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.butter.html) — `output='sos'` önerisi ve $N \ge 4$ eşiği
+- [CMSIS-DSP: Biquad Cascade IIR Filters Using Direct Form I Structure](https://arm-software.github.io/CMSIS-DSP/main/group__BiquadCascadeDF1.html) — DF-I'in sabit noktada neden tercih edildiği
+- [CMSIS-DSP: Biquad Cascade IIR Filters Using a Direct Form II Transposed Structure](https://arm-software.github.io/CMSIS-DSP/main/group__BiquadCascadeDF2T.html) — DF2T'nin dinamik aralık gereksinimi ve neden yalnızca kayan nokta sürümünün bulunduğu
+- [Effect of Coefficient Quantization on IIR Filters — WPI ECE 503 ders notu (PDF)](https://spinlab.wpi.edu/courses/ece503_2014/9-3coefficient_quantization_iir.pdf) — direct form'da her katsayının tüm kutupları etkilemesi
+- [The Effect of Coefficient Quantization on the Performance of a Digital Filter — All About Circuits](https://www.allaboutcircuits.com/technical-articles/effect-coefficient-quantization-performance-digital-filter/) — konunun giriş seviyesinde özeti

--- a/agent/topics.md
+++ b/agent/topics.md
@@ -1,128 +1,172 @@
 # Konu Defteri
 
 > Otonom yazı ajanının kalıcı belleği. Her çalıştırmada okunur ve güncellenir.
+> **Son senkronizasyon: 2026-08-25** (bu tarihten önceki defter üç ay geride kalmıştı).
 
-## Yazıldı (yayında)
+## Yazıldı (yayında, master üzerinde)
 
-- [x] Tümleşik Gereksinim Yönetimi — 2022-04-28 — alan: sistem/gereksinim
-- [x] Yazılım Sistem Mühendisliği — 2022-04-29 — alan: sistem
-- [x] Use Case Tuzakları — 2022-05-01 — alan: gereksinim/analiz
-- [x] Yazılım Proje Yönetimi Pratikleri — 2022-05-03 — alan: proje yönetimi
-- [x] Gereksinimler ve Test: Yedi Eksik Bağlantı — 2022-05-08 — alan: gereksinim/test
-- [x] Fonksiyonel Olmayan Yazılım Gereksinimleri — 2022-07-11 — alan: gereksinim
-- [x] CMake — 2022-07-20 — alan: araçlar
-- [x] Elektrik Kesintisinde Otomatik Açılış — 2022-08-15 — alan: sistem
-- [x] Recursively Delete a Specific Folder — 2022-09-11 — alan: araçlar
-- [x] Merge Files with FFmpeg — 2023-03-12 — alan: araçlar
-- [x] Türkiye'de Debugging Aşamaları — 2023-12-01 — alan: kültür/proje
-- [x] Kayan Nokta Sayılarının Tehlikeleri — 2026-03-25 — alan: gömülü/sayısal
-- [x] Versiyon Kontrol: Git vs SVN vs ClearCase — 2026-03-25 — alan: araçlar
-- [x] MISRA C:2025 ile Neler Değişti — 2026-04-05 — alan: standart/C
-- [x] Yöneylem Araştırması Yöntemleri — 2026-04-14 — alan: matematik/optimizasyon
-- [x] Ölçüm Belirsizliği (GUM Annex F + NCSLI RP-12) — 2026-05-06 — alan: metroloji
-- [x] Kalibrasyon Zincirinin Tepesi (Birincil Standartlar) — 2026-05-07 — alan: metroloji
-- [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14 — alan: gömülü/SoC
+- [x] Hello world! — 1970-01-01
+- [x] Tümleşik Gereksinim Yönetimi — 2022-04-28
+- [x] Yazılım Sistem Mühendisliği — 2022-04-30
+- [x] Use Case Tuzakları — 2022-05-01
+- [x] Yazılım Proje Yönetimi Pratikleri: Başarı ve Başarısızlık — 2022-05-01
+- [x] Gereksinimler ve Test: Yedi Eksik Bağlantı Efsanesi — 2022-05-08
+- [x] Fonksiyonel ve fonksiyonel olmayan yazılım gereksinimleri — 2022-07-11
+- [x] CMake — 2022-07-19
+- [x] Elektrik kesintisinde bilgisayarın otomatik tekrar açılmasını sağlama — 2022-08-15
+- [x] Recursively Delete a Specific Folder — 2022-09-11
+- [x] Merge Files with FFmpeg — 2023-03-12
+- [x] Türkiye'de Debugging aşamaları — 2023-12-01
+- [x] Kayan Nokta Sayılarının Tehlikeleri — 2026-03-25
+- [x] Versiyon Kontrol Sistemleri: Git vs SVN vs ClearCase — 2026-03-25
+- [x] MISRA C:2025 ile Neler Değişti? — 2026-04-05
+- [x] Yöneylem Araştırması Yöntemleri: Kesin ve Metasezgisel Yaklaşımlar — 2026-04-14
+- [x] Ölçtüğünüz Sayı Ne Kadar Doğru? Ölçüm Belirsizliği için Bir Rehber — 2026-05-06
+- [x] Saatçinin Saatini Kim Kalibre Eder? Kalibrasyon Zincirinin Tepesi — 2026-05-07
+- [x] Renode ile Zynq7000 Simülasyonu — 2026-05-14
+- [x] Bandpass Sampling: 1 GHz Sinyali 50 MHz Clock ile Örneklemek — 2026-05-21
+- [x] Sistem Mühendisliği Nedir? — 2026-05-26
+- [x] Kalman Filtresi ve EKF: Gürültülü Veriden Gizli Durumu Kestirmek — 2026-06-02
+- [x] Coupling'i Dengelemek: Yazılım Tasarımında Bağımlılığı Yönetmek — 2026-06-04
+- [x] Antikırılgan: Belirsizlikten ve Kaostan Güç Alan Sistemler — 2026-06-24
+- [x] Python'da Çalışan Filtre Hedefte Neden Patlıyor? IIR Katsayı Kuantizasyonu — 2026-08-25
 
-## Açık PR'lar (insan inceleme bekleniyor)
+## Açık PR'lar (insan inceleme bekleniyor) — 55 adet
 
-| PR # | Başlık | Dal | Açılış | Alan |
-|------|--------|-----|--------|------|
-| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | post/2026-05-20-crc-polinom-secimi-ve-hamming-mesafesi | 2026-05-20 | yazılım zanaatı/hata tespiti |
-| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR Geometrisi | post/2026-05-19-vor-faz-karsilastirma | 2026-05-19 | navigasyon |
-| [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A | post/2026-05-18-mcdc-kapsama-do-178c-dal-a | 2026-05-17 | sertifikasyon |
-| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi (C/C++, Rust) | post/bellek-guvenligi-devrimi | 2026-04-12 | gömülü/güvenlik |
-| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | C'de Tanımsız Davranış (Undefined Behavior) | blog/undefined-behavior | 2026-04-04 | C/derleyici |
-| [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | MISRA C ve Statik Analiz | blog/misra-c-statik-analiz | 2026-03-28 | standart/C (#69 ile çakışma riski!) |
-| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Float Denormalize FTZ/DAZ (eski yazı genişletme) | claude/float-denormalize-ftz-daz | 2026-03-26 | gömülü/sayısal |
+> **UYARI — konu tekrarı birikmiş.** Defter uzun süre güncellenmediği için ajan aynı
+> konuyu birden çok kez yazmış. Tespit edilen kümeler:
+>
+> | Konu | Çakışan PR'lar |
+> |---|---|
+> | `volatile` / `_Atomic` / bellek modeli | #159, #157, #156, #155, #134, #100 — **altı PR** |
+> | WCET analizi | #164, #98, #88 — üç PR |
+> | Watchdog tasarım desenleri | #161, #89 |
+> | MC/DC ve structural coverage | #168, #77 |
+> | Endianness / bitfield wire format | #166, #122 |
+> | MISRA C | #151, #51 ve yayındaki "MISRA C:2025" yazısı |
+>
+> İnceleyen kişiye öneri: her kümeden **bir** PR seçilip diğerleri kapatılmalı.
+> Bu birikim, defterin güncel tutulmamasının doğrudan sonucudur.
 
-> **Not:** PR #51 "MISRA C ve Statik Analiz", zaten yayında olan #69 "MISRA C:2025 ile Neler Değişti?" ile konu olarak çakışıyor olabilir. İnceleyen kişinin dikkatine.
+| PR # | Başlık | Açılış |
+|------|--------|--------|
+| [#176](https://github.com/mavrikant/mavrikant.github.io/pull/176) | Kod Doğru, Veri Yanlış — DO-178C'de Parameter Data Item | 2026-08-24 |
+| [#175](https://github.com/mavrikant/mavrikant.github.io/pull/175) | Zynq-7000 ve S25FL512S — Güç Kesildiğinde QSPI Flash'ta Ne Kalır? | 2026-08-20 |
+| [#174](https://github.com/mavrikant/mavrikant.github.io/pull/174) | MTBF Bir Ömür Değildir — 10⁻⁹ Hedefinin Aritmetiği | 2026-08-19 |
+| [#173](https://github.com/mavrikant/mavrikant.github.io/pull/173) | MIL-STD-1553B Anatomisi — Manchester Kodlama, RT Zamanlaması ve Sessiz Bug'lar | 2026-08-18 |
+| [#172](https://github.com/mavrikant/mavrikant.github.io/pull/172) | CAST-32A'dan AC 20-193'e — Multicore Aviyonikte Karşılıklı Etki Analizi | 2026-07-30 |
+| [#171](https://github.com/mavrikant/mavrikant.github.io/pull/171) | Aviyonik Yazılımda `malloc` Yasak mı? — DO-178C, DO-332 Objektifleri ve TLSF | 2026-07-29 |
+| [#170](https://github.com/mavrikant/mavrikant.github.io/pull/170) | I/Q Örnekleme ve Analitik Sinyal — İki Kanal, Karmaşık Değerler ve Negatif Frekansın Sırrı | 2026-07-28 |
+| [#169](https://github.com/mavrikant/mavrikant.github.io/pull/169) | Rate Monotonic Scheduling — Liu-Layland Sınırından Response Time Analysis'e | 2026-07-27 |
+| [#168](https://github.com/mavrikant/mavrikant.github.io/pull/168) | DO-178C Data ve Control Coupling — MC/DC Bittikten Sonra Yarım Kalan Structural Coverage | 2026-07-26 |
+| [#167](https://github.com/mavrikant/mavrikant.github.io/pull/167) | RAIM — GPS Alıcısı Kendi Doğruluğunu Nasıl Denetler? (Least-Squares Residual, Chi-Square Test ve HPL) | 2026-07-25 |
+| [#166](https://github.com/mavrikant/mavrikant.github.io/pull/166) | C Bit-Field'ları Wire Format Değildir — Endianness, Padding ve Derleyici-Bağımlı Bit Sıralaması | 2026-07-22 |
+| [#165](https://github.com/mavrikant/mavrikant.github.io/pull/165) | AFDX (ARINC 664 P7) Anatomisi — Sanal Bağlantı, BAG ve Determinist Ethernet | 2026-07-14 |
+| [#164](https://github.com/mavrikant/mavrikant.github.io/pull/164) | WCET'i Neden Ölçemezsiniz — Cache, Ölçüm Kuyruğu ve DO-178C 6.3.4.f | 2026-07-13 |
+| [#163](https://github.com/mavrikant/mavrikant.github.io/pull/163) | Abstract Interpretation Pratikte — Interval Domain neyi kanıtlar, neyi kanıtlamaz? | 2026-07-12 |
+| [#162](https://github.com/mavrikant/mavrikant.github.io/pull/162) | ARINC 653 Anatomisi — Aviyonik RTOS'ta Zaman-Uzay Bölümleme ve Sağlık İzleme | 2026-07-11 |
+| [#161](https://github.com/mavrikant/mavrikant.github.io/pull/161) | Watchdog Tasarım Desenleri — Independent, Windowed, Deadman ve Sağlık İzleme | 2026-07-10 |
+| [#160](https://github.com/mavrikant/mavrikant.github.io/pull/160) | Deterministik Derleme — İki Build Slave Arasında Bit-Bit Aynı İkili ve DO-178C Kanıtı | 2026-07-08 |
+| [#159](https://github.com/mavrikant/mavrikant.github.io/pull/159) | volatile Yetmez — C'de eşzamanlılık, bellek modeli ve _Atomic | 2026-07-07 |
+| [#158](https://github.com/mavrikant/mavrikant.github.io/pull/158) | DO-330 Araç Nitelendirmesi — TQL Belirleme, Kriter Matrisi ve Gerçek Araçlar Üzerinden Karar Ağacı | 2026-07-06 |
+| [#157](https://github.com/mavrikant/mavrikant.github.io/pull/157) | volatile Yetmediğinde — Kesme, DMA ve Multicore'da Bellek Sıralaması | 2026-07-05 |
+| [#156](https://github.com/mavrikant/mavrikant.github.io/pull/156) | "volatile" ne değildir — C11 _Atomic ve ARM bellek modeli | 2026-07-05 |
+| [#155](https://github.com/mavrikant/mavrikant.github.io/pull/155) | 'volatile' Her Şeyi Çözmez: ISR Paylaşımı, C11 _Atomic ve ARM Bellek Modeli | 2026-07-03 |
+| [#151](https://github.com/mavrikant/mavrikant.github.io/pull/151) | `setjmp`/`longjmp` Neden DAL A'da Yasak? — Stack Unwind, MISRA C 21.4 ve Assembly Anatomisi | 2026-06-24 |
+| [#150](https://github.com/mavrikant/mavrikant.github.io/pull/150) | Yığın Taşması Sessiz Bir Katildir — Worst-Case Stack Analizi | 2026-06-24 |
+| [#149](https://github.com/mavrikant/mavrikant.github.io/pull/149) | Gerçek zamanlı sistemler hakkında blog yazısı ekle | 2026-06-24 |
+| [#147](https://github.com/mavrikant/mavrikant.github.io/pull/147) | Derleyici optimizasyonlarını elle yazmak (Zynq7000 + GCC, -O0) yazısı | 2026-06-19 |
+| [#146](https://github.com/mavrikant/mavrikant.github.io/pull/146) | Object Code Coverage — DAL A'da Derleyici Boşluğu (DO-178C §6.4.4.2.b) | 2026-06-19 |
+| [#145](https://github.com/mavrikant/mavrikant.github.io/pull/145) | Cortex-A Boot — Reset Vektöründen main()'e Gerçekten Ne Oluyor? | 2026-06-17 |
+| [#135](https://github.com/mavrikant/mavrikant.github.io/pull/135) | MPU vs MMU — ARM'da Donanım Tabanlı Bellek Korumasının Anatomisi | 2026-06-14 |
+| [#134](https://github.com/mavrikant/mavrikant.github.io/pull/134) | `volatile` Yetmez: C'de Eşzamanlılık, MMIO ve `_Atomic` | 2026-06-13 |
+| [#129](https://github.com/mavrikant/mavrikant.github.io/pull/129) | Allan Deviation — IMU Datasheet'inin Gizli Dilini Çözmek | 2026-06-11 |
+| [#124](https://github.com/mavrikant/mavrikant.github.io/pull/124) | Yüksek İrtifada Sessiz Hata — SEU, SECDED ECC ve Bellek Scrubbing | 2026-06-10 |
+| [#122](https://github.com/mavrikant/mavrikant.github.io/pull/122) | Endianness'in Üç Katmanı — ARM BE-8/BE-32, Bitfield Tuzakları ve 1553/429 | 2026-06-09 |
+| [#121](https://github.com/mavrikant/mavrikant.github.io/pull/121) | Lockstep CPU Mimarileri — Cortex-R5 DCLS, CCM-R5 ve DAL A Donanımı | 2026-06-08 |
+| [#120](https://github.com/mavrikant/mavrikant.github.io/pull/120) | Priority Inversion ve Mars Pathfinder — FreeRTOS'ta Yeniden Üretim | 2026-06-08 |
+| [#119](https://github.com/mavrikant/mavrikant.github.io/pull/119) | DMA ve Cache — Cortex-A9 / Zynq-7000 üzerinde sessiz veri bozulması | 2026-06-07 |
+| [#118](https://github.com/mavrikant/mavrikant.github.io/pull/118) | DO-326A ve ED-202A — Aviyonik Siber Güvenlik Sertifikasyonu | 2026-06-05 |
+| [#114](https://github.com/mavrikant/mavrikant.github.io/pull/114) | Sabit Nokta Aritmetik — FPU'suz Cortex-M0'da Q15 FIR Filtresi | 2026-06-04 |
+| [#103](https://github.com/mavrikant/mavrikant.github.io/pull/103) | Kalman Filtresinin Sessiz İraksaması — Joseph Form, Gözlemlenebilirlik ve Tutarlılık Testleri | 2026-06-01 |
+| [#102](https://github.com/mavrikant/mavrikant.github.io/pull/102) | ILS Anatomisi — Localizer 90/150 Hz DDM ve Glide Path Geometrisi | 2026-05-31 |
+| [#101](https://github.com/mavrikant/mavrikant.github.io/pull/101) | ARM GIC — Cortex-A Kesme Denetleyicisinin İçine Bakmak | 2026-05-30 |
+| [#100](https://github.com/mavrikant/mavrikant.github.io/pull/100) | `volatile` Yetmediğinde — Zynq-7000 Üzerinde C11 `_Atomic`, SCU ve Bellek Bariyerleri | 2026-05-29 |
+| [#99](https://github.com/mavrikant/mavrikant.github.io/pull/99) | Dört Aşamalı Veri Analitiği — Mühendislikte Tanımlayıcıdan Kuralcıya | 2026-05-28 |
+| [#98](https://github.com/mavrikant/mavrikant.github.io/pull/98) | WCET Analizi — Statik Yöntemler, Ölçüm Tabanlı Yaklaşımlar ve Cache'in Karanlık Tarafı | 2026-05-28 |
+| [#96](https://github.com/mavrikant/mavrikant.github.io/pull/96) | Fault Tree Analizi ve Minimal Cut Set Hesabı | 2026-05-27 |
+| [#90](https://github.com/mavrikant/mavrikant.github.io/pull/90) | Linker Script Anatomisi — ARM Bare-Metal için Bir .ld Dosyası Satır Satır | 2026-05-26 |
+| [#89](https://github.com/mavrikant/mavrikant.github.io/pull/89) | Watchdog Timer Tasarım Desenleri — Tek-Stage Yanılgısından Rendezvous Pattern'e | 2026-05-24 |
+| [#88](https://github.com/mavrikant/mavrikant.github.io/pull/88) | WCET Analizi: Statik mi, Ölçüm mü, Hibrit mi? | 2026-05-23 |
+| [#79](https://github.com/mavrikant/mavrikant.github.io/pull/79) | CRC Polinom Seçimi ve Hamming Mesafesi | 2026-05-20 |
+| [#78](https://github.com/mavrikant/mavrikant.github.io/pull/78) | VOR Nasıl Çalışır? 30 Hz Faz Karşılaştırması ve DVOR Geometrisi | 2026-05-19 |
+| [#77](https://github.com/mavrikant/mavrikant.github.io/pull/77) | MC/DC Kapsama — DO-178C DAL A'da Modified Condition/Decision Coverage | 2026-05-17 |
+| [#67](https://github.com/mavrikant/mavrikant.github.io/pull/67) | Bellek Güvenliği Devrimi — C/C++ Geliştiricileri İçin Değişen Kurallar | 2026-04-12 |
+| [#54](https://github.com/mavrikant/mavrikant.github.io/pull/54) | Yeni blog yazısı: C'de Tanımsız Davranış (Undefined Behavior) | 2026-04-04 |
+| [#51](https://github.com/mavrikant/mavrikant.github.io/pull/51) | Add blog post: MISRA C ve Statik Analiz | 2026-03-28 |
+| [#50](https://github.com/mavrikant/mavrikant.github.io/pull/50) | Expand denormalize numbers and FTZ/DAZ section in float post | 2026-03-26 |
 
 ## Seçildi / Devam Eden
 
-- **Bandpass Sampling: 1 GHz Sinyali 50 MHz Saatle Örneklemek** —
-  dal: `post/2026-05-21-bandpass-sampling`,
-  dosya: `_posts/2026-05-21-bandpass-sampling.md`,
-  durum: PR açılacak (bu çalıştırma) — alan: RF/DSP.
+- **Python'da Çalışan Filtre Hedefte Neden Patlıyor? IIR Katsayı Kuantizasyonu** —
+  dal: `post/2026-08-25-iir-katsayi-kuantizasyonu-kutup-gocu`,
+  dosya: `_posts/2026-08-25-iir-katsayi-kuantizasyonu-kutup-gocu.md`,
+  durum: PR açıldı (2026-08-25) — alan: sinyal işleme / sayısal gerçekleme.
 
 ## Reddedildi (bu çalıştırma)
 
-- _(bu çalıştırmada konu reddedilmedi; bandpass sampling havuzdan seçildi.)_
+- **Guardbanding ve uygunluk beyanı (JCGM 106 / ILAC-G8 / Z540.3)** — 2026-08-25 —
+  gerekçe: yayındaki "Ölçüm Belirsizliği" yazısının *Örnek 3* bölümü TUR, PFA,
+  guard band çarpanı ve ILAC-G8 vs Z540.3 farkını zaten işliyor. Anlamsal çakışma.
+- **ARM CoreSight / ETM instruction trace** — 2026-08-25 — gerekçe: elde donanım
+  yok; yazı doğrudan dokümantasyonun yeniden ifadesi olurdu (Bölüm 12 anti-pattern).
+- **ARINC 429 anatomisi** — 2026-08-25 — gerekçe: açık PR'larda zaten üç "veri yolu
+  anatomisi" yazısı var (#173 MIL-STD-1553B, #165 AFDX, #162 ARINC 653). Kalıp tekrarı.
 
 ## Fikir Havuzu (aday konular — gelecek çalıştırma için)
 
-Aşağıdaki adaylar, mevcut yazılar + açık PR'larla çakışmıyor ve Bölüm 6 kriterlerini
-geçici olarak karşılıyor. Faz 2'de tekrar değerlendirilmesi gerekir.
+> Aşağıdaki adaylar yukarıdaki **57 açık PR** ve yayındaki yazılarla karşılaştırılarak
+> filtrelenmelidir. Eski havuzun büyük kısmı artık açık PR'lara dönüşmüş durumda.
 
-### Yüksek öncelikli (kalıcı değer + Türkçe boşluk)
+### Hâlâ boş görünen alanlar (yüksek öncelikli)
 
-- [ ] **ARM Cortex-A reset vektöründen `main()`'e: gerçekten ne oluyor?** —
-      alan: gömülü/SoC — Renode yazısının doğal devamı, somut deney imkânı
-- [ ] **MC/DC kapsama: DO-178C DAL A'da neden modified condition/decision şart?** —
-      alan: sertifikasyon — gerçek karar tablosu örneği, decision/condition farkı
-- [ ] **CRC vs checksum: neden CRC-32 değil de CRC-32C / CRC-16-CCITT seçilir?** —
-      alan: yazılım zanaatı — polinom seçimi, hata tespit gücü, bit-hata analizi
-- [ ] **WCET analizi: statik analiz vs ölçüm tabanlı yaklaşımlar, cache etkileri** —
-      alan: gerçek zamanlı — somut örnek (örn. Cortex-R5 üzerinde basit görev)
-- [ ] **IQ örnekleme ve karmaşık sinyaller: gerçek SDR'ye giriş** —
-      alan: RF/SDR — neden negatif frekans, neden 2 kanal
-- [ ] **GIC (Generic Interrupt Controller): SGI/PPI/SPI farkları ve önceliklendirme** —
-      alan: ARM — kesme yönlendirme, multicore'da CPU affinity
-- [ ] **Cache coherency ve MESI: ARM'da CCI/CMN ne yapar, neden yazılım perde
-      (barrier) gerekir?** — alan: ARM — pratik race condition örneği
-- [ ] **Linker script anatomisi: ARM bare-metal için bir `.ld` dosyası satır satır** —
-      alan: gömülü — kendi linker script'i yazma rehberi
-- [ ] **Watchdog tasarım desenleri: tek vs çoklu görev watchdog, deadman switch,
-      windowed watchdog** — alan: güvenilirlik — gerçek tasarım kararları
-- [ ] **`volatile`'ın doğru kullanımı: nerede yetmez, neden `_Atomic` gerekir?** —
-      alan: C/eşzamanlılık — derleyici çıktı analizi
-- [ ] **VOR'un çalışma prensibi: 30 Hz referans + değişken faz nasıl yön verir?** —
-      alan: navigasyon — faz farkı matematiği + sinyal şeması
-- [ ] **ILS anatomisi: localizer 90/150 Hz DDM ve glide slope** —
-      alan: navigasyon — modülasyon derinliği farkı + örnek hesap
-- [ ] **Kalman filtresi tuzakları: numerik stabilite, gözlemlenebilirlik, tuning** —
-      alan: navigasyon/füzyon — basit IMU örneği + Python kodu
-- [ ] **Sabit nokta (Q-format) aritmetik: Cortex-M0'da FPU yokken DSP nasıl yapılır?** —
-      alan: gömülü/DSP — Q15/Q31 örnekleri, overflow yönetimi
+- [ ] **Sabit noktada limit cycle**: sıfır girişte sönmeyen salınım, ölü bant hesabı —
+      bu yazının doğal devamı, alan: sinyal işleme
+- [ ] **IIR bölüm sıralaması ve ölçekleme**: L2/L∞ norm ile taşma-gürültü dengesi
+- [ ] **Deneysel: gerçek bir hata ayıklama seansı** — GDB + Renode üzerinde
+- [ ] **DO-178C §7 konfigürasyon yönetimi**: CC1 vs CC2 kontrol kategorileri,
+      SCI/SECI, hangi veri hangi kategoriye düşer — açık PR'larda hiç yok
+- [ ] **Türetilmiş gereksinimler (derived requirements)** ve emniyet değerlendirmesine
+      geri besleme — DO-178C'nin en yanlış anlaşılan kavramlarından
+- [ ] **ARP4754A FDAL/IDAL tahsisi**: geliştirme güvence seviyesi nasıl atanır
+- [ ] **CORDIC**: FPU'suz donanımda sin/cos/atan2, yakınsama ve kazanç sabiti
+- [ ] **Robustness test tasarımı**: eşdeğerlik sınıfı, sınır değer, DO-178C 6.4.2.2
+- [ ] **DO-333 formel yöntemler eki**: hangi objektif testle, hangisi analizle karşılanır
 
-### Orta öncelikli (kovaya alındı)
+### Orta öncelikli
 
-- [ ] DO-330 araç nitelendirme (Tool Qualification) seviyeleri
-- [ ] ARP4754A — sistem geliştirme süreci
-- [ ] DO-326A / ED-202A havacılık siber güvenliği
-- [ ] FMEA pratikte: gerçek bir alt-sistem üzerinden adım adım
-- [ ] Fault Tree Analysis ile minimal cut set hesabı
-- [ ] FPU denormal performansı: Cortex-A vs x86 davranış farkı
-- [ ] Deterministik build: SOURCE_DATE_EPOCH, reproducible toolchain
-- [ ] Endianness: ağ baytı vs host baytı, ARM'ın iki modu, bitfield tuzakları
-- [ ] DMA yarış koşulları: ARM'da cache invalidation/clean stratejileri
-- [ ] Lockstep CPU mimarisi: TI Hercules / NXP MPC57xx örnekleri
-- [ ] MPU vs MMU: hangisi ne zaman, FreeRTOS-MPU örneği
-- [ ] Statik analiz neyi yakalar / kaçırır: somut C kodu üzerinden Coverity/Polyspace
-- [ ] Radyasyona dayanıklı yazılım: SEU, TMR, scrubbing
+- [ ] FMEA pratikte; Fault Tree ile minimal cut set (#96 ile çakışma kontrolü şart)
+- [ ] Deterministik build (#160 açık — çakışıyor, atla)
 - [ ] ADS-B sinyal yapısı: PPM modülasyon, mesaj formatı
 - [ ] FIR vs IIR: faz cevabı, hesaplama maliyeti, stabilite
+- [ ] ECSS uzay yazılım standartları ailesi (alt-konulara bölünmeli)
 
-### Düşük öncelikli / sonraya bırak
+## Notlar (bu çalıştırma — 2026-08-25)
 
-- [ ] ECSS uzay yazılım standartları ailesi (geniş, alt-konulara bölünmeli)
-- [ ] DO-254 donanım sertifikasyonu (yazarın uzmanlığı ağırlıklı yazılım tarafında)
-- [ ] İzlenebilirlik matrisi (klasik konu, derinlik çıkarmak zor)
-
-## Notlar (bu çalıştırma — 2026-05-21)
-
-- **Bandpass Sampling** seçildi (alan: RF/DSP). Önceki çalıştırmaların ardından
-  açılan PR'lar son üç alt-alanı (sertifikasyon #77, navigasyon #78, yazılım
-  zanaatı/CRC #79) işaretlemişti; bu yazı **bu üç alandan da** son yayınlanan 3
-  posttan da (Renode gömülü/SoC, kalibrasyon ×2) farklı bir alan getiriyor.
-- Yayın kapısı durumu: Bölüm 4 yalnızca "yayın PR ile olmalı" kuralı koyar; backlog
-  büyüklüğüne dair sert bir sınır yoktur. Açık 7 PR olmasına rağmen son yayınlanan
-  yazıdan (Renode, 2026-05-14) bu yana 7 gün geçti — `min_yayin_araligi_gun = 2`
-  şartı fazlasıyla sağlanmış durumda. Bu çalıştırmada yeni PR açıldı.
-- Bandpass sampling konusunun "neden Türkçe içerikte zor bulunuyor" yanıtı:
-  matematik (Vaughan 1991), datasheet okuma (analog input BW), saat phase noise
-  ve filtre tasarımı disiplinlerinin kesişiminde bulunuyor; Türkçe kaynaklar
-  genellikle yalnızca tek bir cepheden ele almış oluyor (genelde Lyons özet
-  çevirisi). Sentez ve somut sayısal örnek boşluğu büyük.
-- Açık PR'lar konusunda inceleme önceliği yorumu (gözlem): #50 ve #51 hâlâ uzun
-  süredir bekliyor; #50 eski yazıyı genişletiyor, #51 ise yayındaki MISRA C:2025
-  ile büyük olasılıkla çakışıyor. İnceleyen kişinin dikkatine.
+- Defter 2026-05-21'den beri güncellenmemişti: 7 açık PR listeliyordu, gerçekte **57**
+  var; yayındaki 5 yazı da eksikti. Bu çalıştırmada tamamı senkronize edildi.
+- Seçilen konu **IIR katsayı kuantizasyonu**. Yayındaki hiçbir yazı ve açık hiçbir PR
+  "IIR", "biquad" veya "kuantizasyon" geçmiyor (grep ile doğrulandı) — alan temiz.
+- Son üç yayın: antikırılgan (sistem düşüncesi), coupling (yazılım tasarımı), Kalman
+  (navigasyon/füzyon). Seçilen konu bu üçünden de farklı alt-alanda.
+- Derinlik öğesi: **deney + benchmark**. Üç bağımsız yöntemle doğrulandı — Durand-Kerner
+  kök bulma, kesin rasyonel aritmetikte Schur-Cohn testi, zaman düzleminde dürtü yanıtı.
+  Kök bulucu ayrıca yeniden-çarpanlama ile doğrulandı (hata ~3e-11).
+- "Neden zor bulunuyor" yanıtı: konu ders kitaplarında (Oppenheim, Proakis) *var* ama
+  soyut duyarlılık türevleri olarak; pratik tarafta ise "SOS kullan" tavsiyesi
+  gerekçesiz bir kural olarak dolaşıyor. İkisini birleştiren, sayı veren ve
+  tekrar üretilebilir bir Türkçe kaynak yok. Ayrıca yaygın bir yanılgı çürütülüyor:
+  "daha çok bit at" — 32 bit sabit nokta ve float32 ölçümde kararsız çıktı.
+- Yayın kapısı: son yayın 2026-06-24, aradan 62 gün geçti; `min_yayin_araligi_gun = 2`
+  fazlasıyla sağlandı. Yerel `bundle exec jekyll build` başarılı; tarayıcıda MathJax
+  (34 container, 0 hata) ve Mermaid (SVG üretildi) doğrulandı.


### PR DESCRIPTION
## Konu ve neden seçildi

8. dereceden bir Butterworth alçak geçiren filtre (`fc/fs = 0,01`) masaüstünde
`float64` ile kusursuz çalışıyor. Katsayıları 16 bite yuvarladığınızda sekiz kutbun
dördü birim çemberin dışına çıkıyor ve filtre patlıyor. Yazı bunu ölçüyor, nedenini
Wilkinson'ın kötü koşullanma sonucuna bağlıyor, ve kaskad biquad'ın aynı 16 bitle
neden kararlı kaldığını gösteriyor.

**Alan rotasyonu:** son üç yayın antikırılgan (sistem düşüncesi), coupling (yazılım
tasarımı) ve Kalman (navigasyon/füzyon) idi. Bu yazı sinyal işleme / sayısal
gerçekleme alanında — üçünden de farklı.

**Çakışma kontrolü:** `_posts/` içinde ve 57 açık PR başlığında "IIR", "biquad",
"kuantizasyon" geçen tek bir kayıt yok (grep ile doğrulandı). Bandpass Sampling yazısı
örnekleme tarafını işliyor, filtre gerçekleme yapılarına hiç girmiyor.

## Derinlik öğesi (Bölüm 7): deney + benchmark

Bütün sayılar bağımlılıksız saf Python ile üretildi ve **üç bağımsız yöntemle**
doğrulandı:

1. **Durand-Kerner kök bulma** — kök bulucunun kendisi de doğrulandı: bulunan kökler
   yeniden çarpanlanıp giriş katsayılarıyla karşılaştırıldığında hata ~3×10⁻¹¹.
2. **Schur-Cohn kararlılık testi**, `fractions.Fraction` ile **kesin rasyonel
   aritmetikte** — yuvarlama hatasının kararı etkilemesi imkânsız.
3. **Zaman düzleminde dürtü yanıtı** — kök bulmaya hiç başvurmayan doğrudan kanıt.

Üçü de aynı sonuca varıyor. Ana ölçümler:

| Katsayı formatı | Direct form | Kaskad biquad |
|---|---|---|
| 16 bit sabit nokta | **kararsız** (max\|z\| = 1,433) | kararlı |
| 32 bit sabit nokta | **kararsız** | — |
| `float32` | **kararsız** | — |
| `float64` | kararlı | — |

İki bulgu özellikle sezgiye aykırı ve yazının omurgasını oluşturuyor:

- **32 bit sabit nokta hâlâ kararsız.** Kararlılık ancak ~40 bitte geliyor. "Daha çok
  bit at" refleksi bu problemi çözmüyor — dahası kararsızlık kelime uzunluğuyla
  tekdüze azalmıyor (yansıma katsayısı 20 bitte 1,0106 iken 24 bitte 1,0701'e çıkıyor).
- **Eşik 8. derecede değil, 4. derecede.** 16 bitte N=4 zaten kırılıyor.

## Kaynaklar

Wilkinson polinomu (Wikipedia + Cleve Moler), SciPy `butter` dokümantasyonundaki
`output='sos'` önerisi ve N≥4 eşiği, CMSIS-DSP'nin DF-I / DF2T sayfaları (DF-I'in
neden Q15/Q31 desteklediği, DF2T'nin neden yalnızca kayan nokta olduğu), WPI ECE 503
ders notu. CMSIS-DSP'de keyfi dereceden direct form IIR fonksiyonunun hiç bulunmadığı
API listesinden doğrulandı.

## Öz-eleştiri (Faz 6'da düzeltilenler)

- `float32` çözünürlüğü 3,5×10⁻⁶ yazılmıştı; doğrusu ULP tabanlı 3,8×10⁻⁶ — düzeltildi.
- "CMSIS-DSP'de IIR demek biquad demektir" ifadesi lattice filtrelerini yok sayıyordu;
  API listesi kontrol edilip ifade düzeltildi.
- Sıra taraması önce Durand-Kerner ile yapılmıştı ve N=4 için sınırda `1.000000`
  veriyordu. Kesin Schur-Cohn testi bu marjinal durumu **kararsız** olarak çözdü;
  yazıda kesin testin sonucu kullanıldı.
- `max\|a\|` tablo başlığındaki kaçışlı borular kramdown'da tabloyu bozuyordu
  (`colspan="2"` ve düşen sütun) — build çıktısı incelenerek yakalandı ve düzeltildi.

## Bu konu neden az bulunuyor?

Konu ders kitaplarında (Oppenheim, Proakis) *var*, ama soyut duyarlılık türevleri
olarak. Pratik tarafta ise "SOS kullan" tavsiyesi gerekçesi verilmeden bir kural
olarak dolaşıyor. İkisini birleştiren, somut sayı veren ve tekrar üretilebilir bir
Türkçe kaynak yok. Ayrıca yaygın bir yanılgıyı ölçümle çürütüyor: `float32`'ye
geçmenin ya da kelime uzunluğunu ikiye katlamanın problemi çözdüğü sanılıyor.

## Doğrulama

- `bundle exec jekyll build` başarılı (yalnızca vendored Bootstrap'ın mevcut Sass
  deprecation uyarıları).
- Tarayıcıda doğrulandı: MathJax 34 container / **0 hata**, Mermaid SVG üretildi,
  7 tablo doğru render edildi, ham `$$` sızıntısı yok.
- Front matter şeması `_posts/2026-05-21-bandpass-sampling.md` ile birebir aynı.
- Yayın tarihi/saati geçmişte (`07:30`), gelecek-tarih tuzağına düşmüyor.

## ⚠️ Ayrıca: `agent/topics.md` defteri senkronize edildi

Defter **2026-05-21'den beri güncellenmemişti** — 7 açık PR listeliyordu, gerçekte
**57** var; yayındaki 5 yazı da eksikti. Bu, ajanın aynı konuyu tekrar tekrar
yazmasına yol açmış. Tespit edilen çakışma kümeleri:

| Konu | Çakışan PR'lar |
|---|---|
| `volatile` / `_Atomic` / bellek modeli | #159, #157, #156, #155, #134, #100 — **altı PR** |
| WCET analizi | #164, #98, #88 |
| Watchdog tasarım desenleri | #161, #89 |
| MC/DC ve structural coverage | #168, #77 |
| Endianness / bitfield wire format | #166, #122 |
| MISRA C | #151, #51 (+ yayındaki "MISRA C:2025" yazısı) |

**Öneri:** her kümeden bir PR seçilip diğerleri kapatılırsa hem backlog küçülür hem de
defter bundan sonra tekrarı engeller.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
